### PR TITLE
Create directory paths before calling install.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -37,6 +37,7 @@ srcdir  = @srcdir@
 SHELL	= /bin/sh
 CC	= @CC@
 INSTALL	= @INSTALL@
+MKDIR_P = @MKDIR_P@
 
 
 ## Bison is generating incorrect parsers.  So do not use, for now
@@ -82,7 +83,9 @@ MANIFEST:
 	find . -type f | sed s/..// > MANIFEST
 
 install : es
+	$(MKDIR_P) $(bindir)
 	$(INSTALL) -s $(srcdir)/es $(bindir)
+	$(MKDIR_P) $(mandir)/man1
 	$(INSTALL) $(srcdir)/doc/es.1 $(mandir)/man1
 
 test	: trip

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,7 @@ dnl saved_CFLAGS="$CFLAGS"
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_INSTALL
+AC_PROG_MKDIR_P
 AC_PROG_YACC
 
 dnl CFLAGS="$CFLAGS $saved_CFLAGS"


### PR DESCRIPTION
See Issue #12 (Error when installing to new directory).

Add the autoconf test AC_PROG_MKDIR_P.
Use MKDIR_P to ensure intermediate directories exist before running install.