### PR TITLE
Fix use after free in heredoc variables

### DIFF
--- a/heredoc.c
+++ b/heredoc.c
@@ -17,11 +17,13 @@ static Here *hereq;
 extern Tree *getherevar(void) {
 	int c;
 	char *s;
+	size_t len;
 	Buffer *buf = openbuffer(0);
 	while (!dnw[c = GETC()])
 		buf = bufputc(buf, c);
+	len = buf->len;
 	s = sealcountedbuffer(buf);
-	if (buf->len == 0) {
+	if (len == 0) {
 		yyerror("null variable name in here document");
 		return NULL;
 	}


### PR DESCRIPTION
After glibc upgrade (I think) one of my scripts started to complain about null variable in here document.
The following may or may not reproduce the problem for you, but `sealcountedbuffer(buf)` frees its argument so using `buf->len` afterwards is illegal.
```
; cat a
{} << X
$a
X
; es a
a:3: null variable name in here document
```