### PR TITLE
Makefile.in: use CC_FOR_BUILD and LDFLAGS_FOR_BUILD when building a

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -70,7 +70,7 @@ es	: ${OFILES} initial.o
 	${CC} -o es ${LDFLAGS} ${OFILES} initial.o ${LIBS}
 
 esdump	: ${OFILES} dump.o
-	${CC} -o esdump ${LDFLAGS} ${OFILES} dump.o ${LIBS}
+	${CC_FOR_BUILD} -o esdump ${LDFLAGS_FOR_BUILD} ${CFILES} dump.c ${LIBS}
 
 clean	:
 	rm -f es ${OFILES} ${GEN} dump.o initial.o


### PR DESCRIPTION
generator.

When cross compiling equivalents to CC, CXX, CPP, CFLAGS, LDFLAGS, etc
etc are defined with the _FOR_BUILD suffix for usage when compiling
any binary that needs to be executed on the system while building.