### PR TITLE
Always use va_copy (musl support)

### DIFF
--- a/print.c
+++ b/print.c
@@ -273,15 +273,10 @@ extern int fmtprint VARARGS2(Format *, format, const char *, fmt) {
 	va_list saveargs = format->args;
 #endif
 
-
 	VA_START(format->args, fmt);
 	n += printfmt(format, fmt);
 	va_end(format->args);
-#ifndef __va_copy
-	format->args = saveargs;
-#else
-	__va_copy(format->args, saveargs);
-#endif
+	va_copy(format->args, saveargs);
 
 	return n + format->flushed;
 }

--- a/stdenv.h
+++ b/stdenv.h
@@ -204,6 +204,11 @@ typedef GETGROUPS_T gidset_t;
 #define	VARARGS2(t1, v1, t2, v2)	(v1, v2, va_alist) t1 v1; t2 v2; va_dcl
 #define	VA_START(ap, var)		va_start(ap)
 
+/* __va_* are defined by the compiler */
+#define va_start(ap)		__va_start(ap)
+#define va_copy(dest, src)	__va_copy(dest, src)
+#define va_end(ap)		__va_end(ap)
+
 #endif
 
 


### PR DESCRIPTION
As the code already assumes that va_start and va_end exists (even when stdarg_h is not defined) i think that using va_copy by default won't cause any regression, but to guarantee i added some defines when stdarg_h is not defined (those definitions works because the compiler export __va_*)

Also should fix issue #24 (actually i'm not sure, as the person said that changing to va_copy weren't enough, but in my machine i was able to build it with musl)

edit: i tested on adelie linux, and in fact the master branch compiles with this minimal change