### PR TITLE
Fix readline/editline support

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -89,20 +89,11 @@
 /* Define if you have the <unistd.h> header file.  */
 #undef HAVE_UNISTD_H
 
-/* Define if you have the editline library (-leditline).  */
-#undef HAVE_LIBEDITLINE
-
-/* Define if you have the readline library (-lreadline).  */
-#undef HAVE_LIBREADLINE
+/* Define if you have a readline function (-lreadline/-ledit).  */
+#undef HAVE_READLINE
 
 /* Define if you have the sun library (-lsun).  */
 #undef HAVE_LIBSUN
-
-/* Define if you have the termcap library (-ltermcap).  */
-#undef HAVE_LIBTERMCAP
-
-/* Define if you have the terminfo library (-lterminfo).  */
-#undef HAVE_LIBTERMINFO
 
 /* Do you have a /dev/fd/ directory? */
 #undef HAVE_DEV_FD

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
+AC_PREREQ([2.58])
 AC_INIT(access.c)
 AC_CONFIG_HEADER(config.h)
 
@@ -14,13 +15,15 @@ rm -f conftest*
 ])
 
 
-use_readline=yes
-use_editline=no
-
-AC_ARG_WITH(readline,
---with-readline		Use GNU Readline, use_readline=yes)
-AC_ARG_WITH(editline,
---with-editline		Use the Editline library, use_editline=yes)
+AC_ARG_WITH([readline],
+	[AS_HELP_STRING([--without-readline], [Do not use GNU Readline])],
+	[],
+	[with_readline=check])
+AC_ARG_WITH([editline],
+	[AS_HELP_STRING([--with-editline],
+		[Use the readline emulation of Editline])],
+	[],
+	[with_editline=no])
 
 AC_CANONICAL_HOST
 
@@ -60,18 +63,30 @@ dnl Checks for libraries.
 
 AC_CHECK_LIB(sun, getpwuid)
 
-if test "$use_readline" = yes || test "$use_editline" = yes
+if test "${with_readline}" != no || test "${with_editline}" = yes
 then
-	AC_CHECK_LIB(terminfo, main)
-	AC_CHECK_LIB(termcap, main)
-	if test "$use_readline" = yes
-	then
-		AC_CHECK_LIB(readline, readline)
-	elif test "$use_editline" = yes
-	then
-		AC_CHECK_LIB(edit, readline)
+	if test "${with_readline}" = yes
+	then readline_libs=readline
 	fi
-
+	if test "${with_editline}" = yes
+	then readline_libs="${readline_libs} edit"
+	fi
+	if test "${with_readline}" = check
+	then readline_libs="${readline_libs} readline"
+	fi
+	AC_SEARCH_LIBS([readline], [${readline_libs}],
+		[],
+		[AC_MSG_ERROR([readline/editline not found])])
+	if \
+		test "${with_readline}" = check &&
+		test "${with_editline}" = yes &&
+		test "${ac_cv_search_readline}" = "-lreadline"
+	then AC_MSG_WARN([editline not found, using readline])
+	fi
+	AC_DEFINE([HAVE_READLINE])
+	AC_SEARCH_LIBS([tputs], [terminfo tinfo termcap],
+		[],
+		[AC_MSG_ERROR([terminfo/termcap library not found])])
 fi
 
 

--- a/esconfig.h
+++ b/esconfig.h
@@ -189,7 +189,7 @@
 # define SYSV_SIGNALS 1
 #endif
 
-#if HAVE_LIBREADLINE || HAVE_LIBEDITLINE
+#if HAVE_READLINE
 # define READLINE 1
 #endif
 


### PR DESCRIPTION
Configuration bugs fixed:
  * `--without-readline` would set `use_readline=yes` when it should have
    set `use_readline=no`.
  * `--with-editline` correctly found libedit, but `HAVE_LIBEDIT` was
    consequently defined rather than `HAVE_LIBEDITLINE`, resulting in a
    useless dependency on libedit since there was no readline
    functionality available.

Slightly altered behavior of `--with-readline` and `--with-editline` to
result in an error when a readline library was explicitly requested:
  * If neither are specified, readline support from libreadline will be
    used if found.  No error will occur if it is not found.  This
    maintains existing behavior.
  * `--without-readline` will disable libreadline, even if it would
    ordinarily be used.  This maintains intended behavior.
  * `--with-editline` will try to find readline support in libedit first,
    then libreadline unless `--with/without-readline` was specified.  If
    neither is found, an error will occur.
  * `--with-readline` and `--with-editline` both specified will try to find
    readline support in libreadline first, then libedit.  This maintains
    existing behavior.  If neither is found, an error will occur.

Other changes:
  * `HAVE_READLINE` is now defined in config.h instead of the separate
    `HAVE_LIBREADLINE` and `HAVE_LIBEDITLINE`.  The first detected library
    will be linked automatically.
  * libtinfo is now searched.  Linux and FreeBSD, for example, use
    libtinfo rather than libterminfo, so the search order for terminal
    capability libraries is terminfo, then tinfo, and finally termcap.
  * `HAVE_LIBTERMCAP` and `HAVE_LIBTERMINFO` in config.h are gone.
    Previously, `AC_CHECK_LIB` would define them, but the switch to
    `AC_SEARCH_LIBS` means they are no longer `AC_DEFINE`'d implicitly if
    found.  Since the library is only needed at link time, and there is
    nothing in the source code relying on them, there is no need to
    define a preprocessor symbol, thus they were not replaced.
  * `AC_PREREQ([2.58])` added since `AS_HELP_STRING` is used.