### PR TITLE
fix typos

### DIFF
--- a/doc/ERRATA
+++ b/doc/ERRATA
@@ -1,7 +1,7 @@
 The section named ``Return Values'' on page 56 introduces the <>
 operator for obtaining the return value of a command.  That operator
 has been renamed <= to avoid conflicting with the posix-compatible
-defintion of <> as ``open for reading and writing.''
+definition of <> as ``open for reading and writing.''
 
 error exceptions now have an additional piece of information.
 the second word (the one after ``error'') is now the name of

--- a/doc/es.1
+++ b/doc/es.1
@@ -36,7 +36,7 @@
 .\" troff will supply the correct intersentence spacing, but only if
 .\" the sentences end at the end of a line.  Explicit spaces, if given,
 .\" are apparently honored and the normal intersentence spacing is
-.\" supressed.
+.\" suppressed.
 .\"
 .\" DaviD W. Sanderson
 .\"-------

--- a/esconfig.h
+++ b/esconfig.h
@@ -126,7 +126,7 @@
  *
  *	SYSV_SIGNALS
  *		True if signal handling follows System V behavior;
- *		otherwise, berkeley signals are assumed.  If you set
+ *		otherwise, Berkeley signals are assumed.  If you set
  *		USE_SIGACTION, this value is ignore.  By System V
  *		behavior, we mean, signal must be called to reinstall
  *		the signal handler after it is invoked.  This behavior

--- a/initial.es
+++ b/initial.es
@@ -594,7 +594,7 @@ if {~ <=$&primitives execfailure} {fn-%exec-failure = $&execfailure}
 #	interactive or batch.
 #
 #	The REPLs are invoked by the shell's main() routine or the . or
-#	eval builtins.  If the -i flag is used or the shell determimes that
+#	eval builtins.  If the -i flag is used or the shell determines that
 #	it's input is interactive, %interactive-loop is invoked; otherwise
 #	%batch-loop is used.
 #
@@ -609,7 +609,7 @@ if {~ <=$&primitives execfailure} {fn-%exec-failure = $&execfailure}
 #	By convention, the REPL must pass commands to the fn %dispatch,
 #	which has the actual responsibility for executing the command.
 #	Whatever routine invokes the REPL (internal, for now) has
-#	the resposibility of setting up fn %dispatch appropriately;
+#	the responsibility of setting up fn %dispatch appropriately;
 #	it is used for implementing the -e, -n, and -x options.
 #	Typically, fn %dispatch is locally bound.
 #

--- a/mksignal
+++ b/mksignal
@@ -74,7 +74,7 @@ sed -n '
 		mesg["SIGMSG"]		= "input data is in the HFT ring buffer"
 		mesg["SIGPRE"]		= "programming exception"
 		mesg["SIGPTY"]		= "pty I/O available"
-		mesg["SIGRETRACT"]	= "HFT monitor mode should be relinguished"
+		mesg["SIGRETRACT"]	= "HFT monitor mode should be relinquished"
 		mesg["SIGSAK"]		= "secure attention key"
 		mesg["SIGSOUND"]	= "HFT sound control has completed"
 		mesg["SIGSTKFLT"]	= "stack fault"

--- a/print.h
+++ b/print.h
@@ -6,7 +6,7 @@ struct Format {
 	va_list args;
 	long flags, f1, f2;
 	int invoker;
-    /* for the buffer maintainence routines */
+    /* for the buffer maintenance routines */
 	char *buf, *bufbegin, *bufend;
 	int flushed;
 	void (*grow)(Format *, size_t);


### PR DESCRIPTION
fixed

doc/ERRATA
doc/es.1
esconfig.h
initial.es
mksignal
print.h

additional typos appear in the following files

CHANGES
examples/friedman/lib/repl.es
examples/friedman/lib/subr.es
examples/friedman/lib/which.es