### PR TITLE
Fix bugs revealed by GCDEBUG.

### DIFF
--- a/glob.c
+++ b/glob.c
@@ -276,7 +276,8 @@ extern List *glob(List *list, StrList *quote) {
 				Ref(StrList *, q0, quote);
 				Ref(StrList *, qr, qp);
 				str = expandhome(str, qp);
-				lr->term = mkstr(str);
+				Term *tmp = mkstr(str);
+				lr->term = tmp;
 				lp = lr;
 				qp = qr;
 				list = l0;

--- a/prim-ctl.c
+++ b/prim-ctl.c
@@ -67,8 +67,8 @@ PRIM(catch) {
 			blocksignals();
 			ExceptionHandler
 				result
-				  = eval(mklist(mkstr("$&noreturn"),
-					        mklist(lp->term, frombody)),
+				  = prim("noreturn",
+					 mklist(lp->term, frombody),
 					 NULL,
 					 evalflags);
 				unblocksignals();


### PR DESCRIPTION
Three classes of error with GCDEBUG (or just GCALWAYS), which probably represent latent memory unsafety:
 - segfault in $&fsplit (which causes crash on startup)
 - segfault in $&catch (which causes crash on exit)
 - segfault in tilde handling (which causes either a crash or the inability to actually expand ~ to the output of %home)

It's unbelievable that I've taken 5-6 years to actually submit this pull request.

Fixes wryun/es-shell#18