### PR TITLE
Add readline completion for variables, primitives, and usernames prefixed with `~`

### DIFF
--- a/es.h
+++ b/es.h
@@ -197,6 +197,7 @@ extern Vector *mkenv(void);
 extern void setnoexport(List *list);
 extern void addtolist(void *arg, char *key, void *value);
 extern List *listvars(Boolean internal);
+extern List *varswithprefix(char *prefix);
 
 typedef struct Push Push;
 extern Push *pushlist;
@@ -313,6 +314,7 @@ extern List *esoptend(void);
 
 extern List *prim(char *s, List *list, Binding *binding, int evalflags);
 extern void initprims(void);
+extern List *primswithprefix(char *prefix);
 
 
 /* split.c */

--- a/input.c
+++ b/input.c
@@ -649,7 +649,6 @@ static char *list_completion_function(const char *text, int state) {
 char **builtin_completion(const char *text, int start, int end) {
 	char **matches = NULL;
 
-	/* var/prim completion.  TODO: complex expressions like `$(a b c)` */
 	if (*text == '$') {
 		wordslistgen = varswithprefix;
 		complprefix = "$";
@@ -665,11 +664,8 @@ char **builtin_completion(const char *text, int start, int end) {
 	}
 
 	/* ~foo => username.  ~foo/bar already gets completed as filename. */
-	/* TODO: deglob the dir as well? i.e., ~foo => /home/foo? */
 	if (!matches && *text == '~' && !strchr(text, '/'))
 		matches = rl_completion_matches(text, rl_username_completion_function);
-
-	/* TODO: command-name completion.  Difficult because of %pathsearch. */
 
 	return matches;
 }
@@ -699,6 +695,7 @@ extern void initinput(void) {
 #if READLINE
 	rl_readline_name = "es";
 
+	/* these two word_break_characters exclude '&' due to primitive completion */
 	rl_completer_word_break_characters = " \t\n\\'`$><=;|{()}";
 	rl_basic_word_break_characters = " \t\n\\'`$><=;|{()}";
 	rl_completer_quote_characters = "'";

--- a/input.c
+++ b/input.c
@@ -32,13 +32,10 @@ static char *history;
 static int historyfd = -1;
 
 #if READLINE
-extern char *readline(char *);
+#include <readline/readline.h>
 extern void add_history(char *);
 extern int read_history(char *);
 extern void stifle_history(int);
-extern void rl_reset_terminal(char *);
-extern char *rl_basic_word_break_characters;
-extern char *rl_completer_quote_characters;
 
 #if ABUSED_GETENV
 static char *stdgetenv(const char *);
@@ -576,6 +573,110 @@ extern Boolean isinteractive(void) {
 
 
 /*
+ * readline integration.
+ */
+#if READLINE
+/* quote -- teach readline how to quote a word in es during completion */
+static char *quote(char *text, int type, char *qp) {
+	char *p, *r;
+
+	/* worst-case size: string is 100% quote characters which will all be
+	 * doubled, plus initial and final quotes and \0 */
+	p = r = ealloc(strlen(text) * 2 + 3);
+	/* supply opening quote if not already present */
+	if (*qp != '\'')
+		*p++ = '\'';
+	while (*text) {
+		/* double any quotes for es quote-escaping rules */
+		if (*text == '\'')
+			*p++ = '\'';
+		*p++ = *text++;
+	}
+	if (type == SINGLE_MATCH)
+		*p++ = '\'';
+	*p = '\0';
+	return r;
+}
+
+/* unquote -- teach es how to unquote a word */
+static char *unquote(char *text, int quote_char) {
+	char *p, *r;
+
+	p = r = ealloc(strlen(text) + 1);
+	while (*text) {
+		*p++ = *text++;
+		if (quote_char && *(text - 1) == '\'' && *text == '\'')
+			++text;
+	}
+	*p = '\0';
+	return r;
+}
+
+static char *complprefix;
+static List *(*wordslistgen)(char *);
+
+static char *list_completion_function(const char *text, int state) {
+	static char **matches = NULL;
+	static int matches_idx, matches_len;
+	int rlen;
+	char *result;
+
+	const int pfx_len = strlen(complprefix);
+
+	if (!state) {
+		const char *name = &text[pfx_len];
+
+		Vector *vm = vectorize(wordslistgen((char *)name));
+		matches = vm->vector;
+		matches_len = vm->count;
+		matches_idx = 0;
+	}
+
+	if (!matches || matches_idx >= matches_len)
+		return NULL;
+
+	rlen = strlen(matches[matches_idx]);
+	result = ealloc(rlen + pfx_len + 1);
+	for (int i = 0; i < pfx_len; i++)
+		result[i] = complprefix[i];
+	strcpy(&result[pfx_len], matches[matches_idx]);
+	result[rlen + pfx_len] = '\0';
+
+	matches_idx++;
+	return result;
+}
+
+char **builtin_completion(const char *text, int start, int end) {
+	char **matches = NULL;
+
+	/* var/prim completion.  TODO: complex expressions like `$(a b c)` */
+	if (*text == '$') {
+		wordslistgen = varswithprefix;
+		complprefix = "$";
+		switch (text[1]) {
+		case '&':
+			wordslistgen = primswithprefix;
+			complprefix = "$&";
+			break;
+		case '^': complprefix = "$^"; break;
+		case '#': complprefix = "$#"; break;
+		}
+		matches = rl_completion_matches(text, list_completion_function);
+	}
+
+	/* ~foo => username.  ~foo/bar already gets completed as filename. */
+	/* TODO: deglob the dir as well? i.e., ~foo => /home/foo? */
+	if (!matches && *text == '~' && !strchr(text, '/'))
+		matches = rl_completion_matches(text, rl_username_completion_function);
+
+	/* TODO: command-name completion.  Difficult because of %pathsearch. */
+
+	return matches;
+}
+#endif /* READLINE */
+
+
+/*
  * initialization
  */
 
@@ -596,7 +697,17 @@ extern void initinput(void) {
 	initparse();
 
 #if READLINE
-	rl_basic_word_break_characters=" \t\n\\'`$><=;|&{()}";
-		rl_completer_quote_characters="'";
+	rl_readline_name = "es";
+
+	rl_completer_word_break_characters = " \t\n\\'`$><=;|{()}";
+	rl_basic_word_break_characters = " \t\n\\'`$><=;|{()}";
+	rl_completer_quote_characters = "'";
+	rl_special_prefixes = "$";
+
+	rl_attempted_completion_function = builtin_completion;
+
+	rl_filename_quote_characters = " \t\n\\`$><=;|&{()}";
+	rl_filename_quoting_function = quote;
+	rl_filename_dequoting_function = unquote;
 #endif
 }

--- a/prim.c
+++ b/prim.c
@@ -13,6 +13,20 @@ extern List *prim(char *s, List *list, Binding *binding, int evalflags) {
 	return (*p)(list, binding, evalflags);
 }
 
+static char *list_prefix;
+
+static void listwithprefix(void *arg, char *key, void *value) {
+	if (strneq(key, list_prefix, strlen(list_prefix)))
+		addtolist(arg, key, value);
+}
+
+extern List *primswithprefix(char *prefix) {
+	Ref(List *, primlist, NULL);
+	list_prefix = prefix;
+	dictforall(prims, listwithprefix, &primlist);
+	RefReturn(primlist);
+}
+
 PRIM(primitives) {
 	static List *primlist = NULL;
 	if (primlist == NULL) {

--- a/stdenv.h
+++ b/stdenv.h
@@ -102,6 +102,10 @@ extern void *qsort(
 );
 #endif /* !STDC_HEADERS */
 
+#if READLINE
+# include <stdio.h>
+#endif
+
 #include <sys/wait.h>
 #include <time.h>
 

--- a/var.c
+++ b/var.c
@@ -321,11 +321,27 @@ static void listinternal(void *arg, char *key, void *value) {
 		addtolist(arg, key, value);
 }
 
+static char *list_prefix;
+
+static void listwithprefix(void *arg, char *key, void *value) {
+	if (strneq(key, list_prefix, strlen(list_prefix)))
+		addtolist(arg, key, value);
+}
+
 /* listvars -- return a list of all the (dynamic) variables */
 extern List *listvars(Boolean internal) {
 	Ref(List *, varlist, NULL);
 	dictforall(vars, internal ? listinternal : listexternal, &varlist);
 	varlist = sortlist(varlist);
+	RefReturn(varlist);
+}
+
+/* varswithprefix -- return a list of all the (dynamic) variables
+ * matching the given prefix */
+extern List *varswithprefix(char *prefix) {
+	Ref(List *, varlist, NULL);
+	list_prefix = prefix;
+	dictforall(vars, listwithprefix, &varlist);
 	RefReturn(varlist);
 }
 


### PR DESCRIPTION
This is a little incomplete -- it doesn't handle complex var syntax like `$(x y z)`, and much more importantly, it does not include command completion at all.  Command completion would need significant cleverness and effort on its own to handle the fact that `%pathsearch` is a hook.