### PR TITLE
Use esopt() for option parsing in main

### DIFF
--- a/access.c
+++ b/access.c
@@ -104,7 +104,7 @@ PRIM(access) {
 	const char * const usage = "access [-n name] [-1e] [-rwx] [-fdcblsp] path ...";
 
 	gcdisable();
-	esoptbegin(list, "$&access", usage);
+	esoptbegin(list, "$&access", usage, TRUE);
 	while ((c = esopt("bcdefln:prswx1")) != EOF)
 		switch (c) {
 		case 'n':	suffix = getstr(esoptarg());	break;

--- a/es.h
+++ b/es.h
@@ -303,7 +303,7 @@ extern Boolean resetterminal;
 
 /* opt.c */
 
-extern void esoptbegin(List *list, const char *caller, const char *usage);
+extern void esoptbegin(List *list, const char *caller, const char *usage, Boolean throws);
 extern int esopt(const char *options);
 extern Term *esoptarg(void);
 extern List *esoptend(void);

--- a/main.c
+++ b/main.c
@@ -222,5 +222,5 @@ getopt_done:
 		return 1;
 
 	EndExceptionHandler
-	RefEnd(argp);
+	RefEnd2(argp, args);
 }

--- a/main.c
+++ b/main.c
@@ -99,7 +99,6 @@ static noreturn usage(void) {
 /* main -- initialize, parse command arguments, and start running */
 int main(int argc, char **argv) {
 	int c;
-	Ref(List *, args, NULL);
 
 	volatile int runflags = 0;		/* -[einvxL] */
 	volatile Boolean protected = FALSE;	/* -p */
@@ -121,8 +120,7 @@ int main(int argc, char **argv) {
 	if (*argv[0] == '-')
 		loginshell = TRUE;
 
-	args = listify(argc, argv);
-
+	Ref(List *, args, listify(argc, argv));
 	esoptbegin(args->next, NULL, NULL, FALSE);
 	while ((c = esopt("eilxvnpodsc:?GIL")) != EOF)
 		switch (c) {

--- a/main.c
+++ b/main.c
@@ -13,9 +13,6 @@ Boolean gcinfo		= FALSE;	/* -I */
 /* extern int getopt (int argc, char **argv, const char *optstring); */
 /* #endif */
 
-extern int optind;
-extern char *optarg;
-
 /* extern int isatty(int fd); */
 extern char **environ;
 
@@ -102,8 +99,7 @@ static noreturn usage(void) {
 /* main -- initialize, parse command arguments, and start running */
 int main(int argc, char **argv) {
 	int c;
-	volatile int ac;
-	char **volatile av;
+	Ref(List *, args, NULL);
 
 	volatile int runflags = 0;		/* -[einvxL] */
 	volatile Boolean protected = FALSE;	/* -p */
@@ -125,9 +121,12 @@ int main(int argc, char **argv) {
 	if (*argv[0] == '-')
 		loginshell = TRUE;
 
-	while ((c = getopt(argc, argv, "eilxvnpodsc:?GIL")) != EOF)
+	args = listify(argc, argv);
+
+	esoptbegin(args->next, NULL, NULL, FALSE);
+	while ((c = esopt("eilxvnpodsc:?GIL")) != EOF)
 		switch (c) {
-		case 'c':	cmd = optarg;			break;
+		case 'c':	cmd = getstr(esoptarg());	break;
 		case 'e':	runflags |= eval_exitonfalse;	break;
 		case 'i':	runflags |= run_interactive;	break;
 		case 'n':	runflags |= run_noexec;		break;
@@ -140,7 +139,7 @@ int main(int argc, char **argv) {
 		case 'p':	protected = TRUE;		break;
 		case 'o':	keepclosed = TRUE;		break;
 		case 'd':	allowquit = TRUE;		break;
-		case 's':	cmd_stdin = TRUE;			goto getopt_done;
+		case 's':	cmd_stdin = TRUE;		goto getopt_done;
 #if GCVERBOSE
 		case 'G':	gcverbose = TRUE;		break;
 #endif
@@ -152,6 +151,8 @@ int main(int argc, char **argv) {
 		}
 
 getopt_done:
+	Ref(List *, argp, esoptend());
+
 	if (cmd_stdin && cmd != NULL) {
 		eprint("es: -s and -c are incompatible\n");
 		exit(1);
@@ -165,14 +166,11 @@ getopt_done:
 
 	if (
 		cmd == NULL
-	     && (optind == argc || cmd_stdin)
+	     && (argp == NULL || cmd_stdin)
 	     && (runflags & run_interactive) == 0
 	     && isatty(0)
 	)
 		runflags |= run_interactive;
-
-	ac = argc;
-	av = argv;
 
 	ExceptionHandler
 		roothandler = &_localhandler;	/* unhygeinic */
@@ -192,20 +190,21 @@ getopt_done:
 		if (loginshell)
 			runesrc();
 	
-		if (cmd == NULL && !cmd_stdin && optind < ac) {
+		if (cmd == NULL && !cmd_stdin && argp != NULL) {
 			int fd;
-			char *file = av[optind++];
+			char *file = getstr(argp->term);
+			argp = argp->next;
 			if ((fd = eopen(file, oOpen)) == -1) {
 				eprint("%s: %s\n", file, esstrerror(errno));
 				return 1;
 			}
-			vardef("*", NULL, listify(ac - optind, av + optind));
+			vardef("*", NULL, argp);
 			vardef("0", NULL, mklist(mkstr(file), NULL));
 			return exitstatus(runfd(fd, file, runflags));
 		}
 	
-		vardef("*", NULL, listify(ac - optind, av + optind));
-		vardef("0", NULL, mklist(mkstr(av[0]), NULL));
+		vardef("*", NULL, argp);
+		vardef("0", NULL, mklist(mkstr(argv[0]), NULL));
 		if (cmd != NULL)
 			return exitstatus(runstring(cmd, NULL, runflags));
 		return exitstatus(runfd(0, "stdin", runflags));
@@ -223,4 +222,5 @@ getopt_done:
 		return 1;
 
 	EndExceptionHandler
+	RefEnd(argp);
 }

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -46,7 +46,7 @@ PRIM(dot) {
 	volatile int runflags = (evalflags & eval_inchild);
 	const char * const usage = ". [-einvx] file [arg ...]";
 
-	esoptbegin(list, "$&dot", usage);
+	esoptbegin(list, "$&dot", usage, TRUE);
 	while ((c = esopt("einvx")) != EOF)
 		switch (c) {
 		case 'e':	runflags |= eval_exitonfalse;	break;


### PR DESCRIPTION
When I filed #60 I forgot that es already has built-in option parsing!  So for consistency and concision's sake let's use that for main() as well.

Seems to work with trip.es and GCDEBUG (when built on top of #52).

I tried a much more extreme change to main and other es entry points in https://github.com/jpco/es-shell/blob/es-main/runtime.es#L219 but couldn't get the exact behavior right :/

This fixes #60.  Should be otherwise completely transparent to users.