### PR TITLE
Use stricter build flags in circleci's es build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run:
           name: Build
-          command: make
+          command: make 'ADDCFLAGS=-DGCDEBUG=1 -DREF_ASSERTIONS=1'
 
       - run:
           name: Test


### PR DESCRIPTION
This should help find fresh memory/ref bugs before they get merged.

I set the values via make command-line flags mostly for expediency -- if it's preferable to do something in `./configure` or similar, I'll happily do that.