### PR TITLE
Minor overhaul of history writing

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -52,12 +52,12 @@ VPATH = $(srcdir)
 HFILES	= config.h es.h gc.h input.h prim.h print.h sigmsgs.h \
 	  stdenv.h syntax.h term.h var.h
 CFILES	= access.c closure.c conv.c dict.c eval.c except.c fd.c gc.c glob.c \
-	  glom.c input.c heredoc.c list.c main.c match.c open.c opt.c \
+	  glom.c input.c heredoc.c history.c list.c main.c match.c open.c opt.c \
 	  prim-ctl.c prim-etc.c prim-io.c prim-sys.c prim.c print.c proc.c \
 	  sigmsgs.c signal.c split.c status.c str.c syntax.c term.c token.c \
 	  tree.c util.c var.c vec.c version.c y.tab.c dump.c
 OFILES	= access.o closure.o conv.o dict.o eval.o except.o fd.o gc.o glob.o \
-	  glom.o input.o heredoc.o list.o main.o match.o open.o opt.o \
+	  glom.o input.o heredoc.o history.o list.o main.o match.o open.o opt.o \
 	  prim-ctl.o prim-etc.o prim-io.o prim-sys.o prim.o print.o proc.o \
 	  sigmsgs.o signal.o split.o status.o str.o syntax.o term.o token.o \
 	  tree.o util.o var.o vec.o version.o y.tab.o

--- a/Makefile.in
+++ b/Makefile.in
@@ -126,6 +126,7 @@ glob.o : glob.c es.h config.h stdenv.h gc.h
 glom.o : glom.c es.h config.h stdenv.h gc.h 
 input.o : input.c es.h config.h stdenv.h input.h 
 heredoc.o : heredoc.c es.h config.h stdenv.h gc.h input.h syntax.h 
+history.o : history.c es.h config.h stdenv.h gc.h input.h 
 list.o : list.c es.h config.h stdenv.h gc.h 
 main.o : main.c es.h config.h stdenv.h 
 match.o : match.c es.h config.h stdenv.h 

--- a/doc/es.1
+++ b/doc/es.1
@@ -2470,7 +2470,8 @@ Reads input from the current input source, printing
 before reading anything and
 .I prompt2
 before reading continued lines.
-Returns a code fragment suitable for execution.
+Returns a code fragment suitable for execution as the first value and the input
+string which generated the code fragment as the second.
 Raises the exception
 .Cr eof
 on end of input.
@@ -2690,7 +2691,7 @@ The following primitives implement the similarly named settor functions:
 .ta 1.75i 3.5i
 .Ds
 .ft \*(Cf
-sethistory	setnoexport	setsignals
+setnoexport	setsignals
 .ft R
 .De
 .PP
@@ -2706,24 +2707,32 @@ limit	limit
 readfrom	%readfrom
 time	time
 writeto	%writeto
+writehistory	%write-history
 .ft R
 .De
 .PP
-The primitive
+The primitives
 .Cr resetterminal
-is if
+and
+.Cr sethistory
+are if
 .I es
 is compiled with support for the
 .I readline
 or
 .I editline
 libraries.
-It is used in the implementation of settor functions of the
+The former is used in the implementation of settor functions of the
 .Cr TERM
 and
 .Cr TERMCAP
 variables to notify the line editing packages that the terminal
 configuration has changed.
+The latter is used for the
+.Cr set-history
+settor variable when
+.I readline
+support is compiled in.
 .PP
 Several primitives are not directly associated with other function.
 They are:

--- a/es.h
+++ b/es.h
@@ -302,15 +302,17 @@ extern Boolean resetterminal;
 
 
 /* history.c */
+#if READLINE
 extern void inithistory(void);
+
+extern void sethistory(char *file);
+extern void loghistory(char *cmd);
+#endif
 
 extern Boolean pendinghistory(void);
 extern void addhistbuf(char *line, size_t len);
 extern char *dumphistbuf(void);
 extern void discardhistbuf(void);
-
-extern void sethistory(char *file);
-extern void loghistory(char *cmd);
 
 
 /* opt.c */

--- a/es.h
+++ b/es.h
@@ -282,7 +282,6 @@ extern Boolean streq2(const char *s, const char *t1, const char *t2);
 extern char *prompt, *prompt2;
 extern Tree *parse(char *esprompt1, char *esprompt2);
 extern Tree *parsestring(const char *str);
-extern void sethistory(char *file);
 extern Boolean isinteractive(void);
 extern void initinput(void);
 extern void resetparser(void);
@@ -300,6 +299,18 @@ extern List *runstring(const char *str, const char *name, int flags);
 #if READLINE
 extern Boolean resetterminal;
 #endif
+
+
+/* history.c */
+extern void inithistory(void);
+
+extern Boolean pendinghistory(void);
+extern void addhistbuf(char *line, size_t len);
+extern char *dumphistbuf(void);
+extern void discardhistbuf(void);
+
+extern void sethistory(char *file);
+extern void loghistory(char *cmd);
 
 
 /* opt.c */

--- a/heredoc.c
+++ b/heredoc.c
@@ -43,7 +43,6 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 		yyerror("here document eof-marker contains a newline");
 		return NULL;
 	}
-	disablehistory = TRUE;
 
 	for (tree = NULL, tailp = &tree, buf = openbuffer(0);;) {
 		int c;
@@ -63,7 +62,6 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 			if (c == EOF) {
 				yyerror("incomplete here document");
 				freebuffer(buf);
-				disablehistory = FALSE;
 				return NULL;
 			}
 			if (c == '$' && !quoted && (c = GETC()) != '$') {
@@ -78,7 +76,6 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 				var = getherevar();
 				if (var == NULL) {
 					freebuffer(buf);
-					disablehistory = FALSE;
 					return NULL;
 				}
 				*tailp = treecons(var, NULL);
@@ -92,7 +89,6 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 		}
 	}
 
-	disablehistory = FALSE;
 	return tree->CDR == NULL ? tree->CAR : tree;
 }
 
@@ -142,5 +138,4 @@ extern Boolean queueheredoc(Tree *t) {
 
 extern void emptyherequeue(void) {
 	hereq = NULL;
-	disablehistory = FALSE;
 }

--- a/history.c
+++ b/history.c
@@ -1,0 +1,132 @@
+/* history.c -- control the history file ($Revision: 1.1.1.1 $) */
+
+#include "es.h"
+#include "gc.h"
+#include "input.h"
+
+
+/*
+ * constants
+ */
+
+#define	BUFSIZE		((size_t) 4096)		/* buffer size to fill reads into */
+
+
+/*
+ * globals
+ */
+
+static char *history;
+static int historyfd = -1;
+static Buffer *histbuffer = NULL;
+
+#if READLINE
+extern void add_history(char *);
+extern int read_history(char *);
+extern void stifle_history(int);
+#endif
+
+
+/*
+ * histbuffer -- build the history line during input and dump it as a gc-string
+ */
+
+extern Boolean pendinghistory() {
+	return histbuffer != NULL;
+}
+
+extern void addhistbuf(char *line, size_t len) {
+	if (line == NULL || len == 0)
+		return;
+	if (histbuffer == NULL)
+		histbuffer = openbuffer(BUFSIZE);
+	histbuffer = bufncat(histbuffer, line, len);
+}
+
+extern char *dumphistbuf() {
+	char *s, *p;
+        size_t len;
+	if (histbuffer == NULL)
+		return NULL;
+
+	s = sealcountedbuffer(histbuffer);
+	histbuffer = NULL;
+
+	len = strlen(s);
+	if (len > 0 && s[len - 1] == '\n')
+		s[len - 1] = '\0';
+
+	for (p = s; *p != '\0'; p++)
+		switch(*p) {
+		case '#': case '\n':	goto retnull;
+		case ' ': case '\t':	break;
+		default:		goto retreal;
+		}
+retnull:
+	return NULL;
+retreal:
+	return s;
+}
+
+extern void discardhistbuf() {
+	if (histbuffer == NULL)
+		return;
+	freebuffer(histbuffer);
+	histbuffer = NULL;
+}
+
+
+/*
+ * history file
+ */
+
+/* loghistory -- write the last command out to a file */
+extern void loghistory(char *cmd) {
+	size_t len;
+	if (cmd == NULL)
+		return;
+#if READLINE
+	add_history(cmd);
+#endif
+	if (history == NULL)
+		return;
+	if (historyfd == -1) {
+		historyfd = eopen(history, oAppend);
+		if (historyfd == -1) {
+			eprint("history(%s): %s\n", history, esstrerror(errno));
+			vardef("history", NULL, NULL);
+			return;
+		}
+	}
+	len = strlen(cmd);
+	ewrite(historyfd, cmd, len);
+	ewrite(historyfd, "\n", 1);
+}
+
+/* sethistory -- change the file for the history log */
+extern void sethistory(char *file) {
+	if (historyfd != -1) {
+		close(historyfd);
+		historyfd = -1;
+	}
+#if READLINE
+	/* Attempt to populate readline history with new history file. */
+	stifle_history(50000); /* Keep memory usage within sane-ish bounds. */
+	read_history(file);
+#endif
+	history = file;
+}
+
+
+/*
+ * initialization
+ */
+
+/* inithistory -- called at dawn of time from main() */
+extern void inithistory(void) {
+	/* declare the global roots */
+	globalroot(&history);		/* history file */
+
+	/* mark the historyfd as a file descriptor to hold back from forked children */
+	registerfd(&historyfd, TRUE);
+}

--- a/history.c
+++ b/history.c
@@ -17,7 +17,6 @@
  */
 
 static Buffer *histbuffer = NULL;
-static char *history;
 
 #if READLINE
 extern void add_history(char *);
@@ -26,6 +25,8 @@ extern void stifle_history(int);
 extern int append_history(int, const char *);
 extern void using_history(void);
 
+static char *history;
+
 #if 0
 /* These split history file entries by timestamp, which allows readline to pick up
  * multi-line commands correctly across process boundaries.  Disabled by default,
@@ -33,8 +34,6 @@ extern void using_history(void);
 static int history_write_timestamps = 1;
 static char history_comment_char = '#';
 #endif
-#else
-static int historyfd = -1;
 #endif
 
 
@@ -112,32 +111,6 @@ extern void sethistory(char *file) {
 	read_history(file);
 	history = file;
 }
-#else /* !READLINE */
-extern void loghistory(char *cmd) {
-	size_t len;
-	if (cmd == NULL || history == NULL)
-		return;
-	if (historyfd == -1) {
-		historyfd = eopen(history, oAppend);
-		if (historyfd == -1) {
-			eprint("history(%s): %s\n", history, esstrerror(errno));
-			vardef("history", NULL, NULL);
-			return;
-		}
-	}
-	len = strlen(cmd);
-	ewrite(historyfd, cmd, len);
-	ewrite(historyfd, "\n", 1);
-}
-
-extern void sethistory(char *file) {
-	if (historyfd != -1) {
-		close(historyfd);
-		historyfd = -1;
-	}
-	history = file;
-}
-#endif
 
 
 /*
@@ -148,11 +121,6 @@ extern void sethistory(char *file) {
 extern void inithistory(void) {
 	/* declare the global roots */
 	globalroot(&history);		/* history file */
-
-#if READLINE
 	using_history();
-#else
-	/* mark the historyfd as a file descriptor to hold back from forked children */
-	registerfd(&historyfd, TRUE);
-#endif
 }
+#endif

--- a/history.c
+++ b/history.c
@@ -16,14 +16,25 @@
  * globals
  */
 
-static char *history;
-static int historyfd = -1;
 static Buffer *histbuffer = NULL;
+static char *history;
 
 #if READLINE
 extern void add_history(char *);
 extern int read_history(char *);
 extern void stifle_history(int);
+extern int append_history(int, const char *);
+extern void using_history(void);
+
+#if 0
+/* These split history file entries by timestamp, which allows readline to pick up
+ * multi-line commands correctly across process boundaries.  Disabled by default,
+ * because it leaves the history file itself kind of ugly. */
+static int history_write_timestamps = 1;
+static char history_comment_char = '#';
+#endif
+#else
+static int historyfd = -1;
 #endif
 
 
@@ -80,15 +91,31 @@ extern void discardhistbuf() {
  * history file
  */
 
-/* loghistory -- write the last command out to a file */
+#if READLINE
 extern void loghistory(char *cmd) {
-	size_t len;
+	int err;
 	if (cmd == NULL)
 		return;
-#if READLINE
 	add_history(cmd);
-#endif
 	if (history == NULL)
+		return;
+
+	if ((err = append_history(1, history))) {
+		eprint("history(%s): %s\n", history, esstrerror(err));
+		vardef("history", NULL, NULL);
+	}
+}
+
+extern void sethistory(char *file) {
+	/* Attempt to populate readline history with new history file. */
+	stifle_history(50000); /* Keep memory usage within sane-ish bounds. */
+	read_history(file);
+	history = file;
+}
+#else /* !READLINE */
+extern void loghistory(char *cmd) {
+	size_t len;
+	if (cmd == NULL || history == NULL)
 		return;
 	if (historyfd == -1) {
 		historyfd = eopen(history, oAppend);
@@ -103,19 +130,14 @@ extern void loghistory(char *cmd) {
 	ewrite(historyfd, "\n", 1);
 }
 
-/* sethistory -- change the file for the history log */
 extern void sethistory(char *file) {
 	if (historyfd != -1) {
 		close(historyfd);
 		historyfd = -1;
 	}
-#if READLINE
-	/* Attempt to populate readline history with new history file. */
-	stifle_history(50000); /* Keep memory usage within sane-ish bounds. */
-	read_history(file);
-#endif
 	history = file;
 }
+#endif
 
 
 /*
@@ -127,6 +149,10 @@ extern void inithistory(void) {
 	/* declare the global roots */
 	globalroot(&history);		/* history file */
 
+#if READLINE
+	using_history();
+#else
 	/* mark the historyfd as a file descriptor to hold back from forked children */
 	registerfd(&historyfd, TRUE);
+#endif
 }

--- a/initial.es
+++ b/initial.es
@@ -599,12 +599,12 @@ if {~ <=$&primitives execfailure} {fn-%exec-failure = $&execfailure}
 #	%batch-loop is used.
 #
 #	The function %parse can be used to call the parser, which returns
-#	an es command.  %parse takes two arguments, which are used as the
-#	main and secondary prompts, respectively.  %parse typically returns
-#	one line of input, but es allows commands (notably those with braces
-#	or backslash continuations) to continue across multiple lines; in
-#	that case, the complete command and not just one physical line is
-#	returned.
+#	an es command and the input string which was parsed to generate the
+#	command.  %parse takes two arguments, which are used as the main and
+#	secondary prompts, respectively.  %parse typically returns one line of
+#	input, but es allows commands (notably those with braces or backslash
+#	continuations) to continue across multiple lines; in that case, the
+#	complete command and not just one physical line is returned.
 #
 #	By convention, the REPL must pass commands to the fn %dispatch,
 #	which has the actual responsibility for executing the command.
@@ -612,6 +612,12 @@ if {~ <=$&primitives execfailure} {fn-%exec-failure = $&execfailure}
 #	the responsibility of setting up fn %dispatch appropriately;
 #	it is used for implementing the -e, -n, and -x options.
 #	Typically, fn %dispatch is locally bound.
+#
+#	The input line which is returned as the second value from %parse is
+#	passed to the %write-history function.  If the $&writehistory primitive
+#	is available (when readline support is compiled in), %write-history is
+#	set by default to that.  Otherwise, %write-history appends the input
+#	line to $history, if set.
 #
 #	The %parse function raises the eof exception when it encounters
 #	an end-of-file on input.  You can probably simulate the C shell's

--- a/initial.es
+++ b/initial.es
@@ -655,6 +655,10 @@ fn %interactive-loop {
 			} {~ $e exit} {
 				throw $e $type $msg
 			} {~ $e error} {
+				if {~ $type '$&parse' && ~ $msg(1) 'syntax error'} {
+					%write-history $msg(2)
+					msg = $msg(1)
+				}
 				echo >[1=2] $msg
 				$fn-%dispatch false
 			} {~ $e signal} {

--- a/input.c
+++ b/input.c
@@ -313,12 +313,21 @@ extern Tree *parse(char *pr1, char *pr2) {
 	gcenable();
 
 	if (result || error != NULL) {
-		char *e;
+		char *e, *h;
 		assert(error != NULL);
 		e = error;
 		error = NULL;
-		discardhistbuf();
-		fail("$&parse", "%s", e);
+		gcdisable();
+		h = dumphistbuf();
+		Ref(List *, ex, mklist(mkstr("error"),
+				       mklist(mkstr("$&parse"),
+					      mklist(mkstr(e),
+						     (h == NULL
+						      ? NULL
+						      : mklist(mkstr(h), NULL))))));
+		gcenable();
+		throw(ex);
+		RefEnd(ex);
 	}
 
 #if LISPTREES

--- a/input.c
+++ b/input.c
@@ -321,10 +321,6 @@ extern Tree *parse(char *pr1, char *pr2) {
 		fail("$&parse", "%s", e);
 	}
 
-	if (input->runflags & run_interactive)
-		loghistory(dumphistbuf());
-        else discardhistbuf();
-
 #if LISPTREES
 	if (input->runflags & run_lisptrees)
 		eprint("%B\n", parsetree);
@@ -474,6 +470,7 @@ extern Tree *parseinput(Input *in) {
 
 	ExceptionHandler
 		result = parse(NULL, NULL);
+		discardhistbuf();
 		if (get(in) != EOF)
 			fail("$&parse", "more than one value in term");
 	CatchException (e)

--- a/input.h
+++ b/input.h
@@ -27,7 +27,6 @@ struct Input {
 
 extern Input *input;
 extern void unget(Input *in, int c);
-extern Boolean disablehistory;
 extern void yyerror(char *s);
 
 

--- a/main.c
+++ b/main.c
@@ -174,7 +174,9 @@ getopt_done:
 		roothandler = &_localhandler;	/* unhygeinic */
 
 		initinput();
+#if READLINE
 		inithistory();
+#endif
 		initprims();
 		initvars();
 	

--- a/main.c
+++ b/main.c
@@ -174,6 +174,7 @@ getopt_done:
 		roothandler = &_localhandler;	/* unhygeinic */
 
 		initinput();
+		inithistory();
 		initprims();
 		initvars();
 	


### PR DESCRIPTION
With this PR, the way history writing works is like this:
1. During command input, the input line is buffered in memory
2. When `%parse` returns a full parsed command, it also returns the input that produced the command
3. `%interactive-loop` passes the input to the function `%write-history`
4. If readline support is compiled in, `%write-history` puts the input in the readline history log and asks the history library to write it to the `$history` file (or, technically, whatever was passed to `$&sethistory` most recently).
5. If readline support is NOT compiled in, then there is no `$&sethistory` or other built-in history behavior, and `%write-history` is:

```
fn %write-history cmd {
  if {!~ $history ()} {
    echo $cmd >> $history
  }
}
```

Buffering the full command input until returning produces much nicer behavior for multi-line commands than the line-by-line logging that es did previously.  With readline on, it makes scrolling up into history for multi-line commands pleasant; with readline off, it still helps prevent "interleaved" commands in the off chance that the user is writing two multi-line commands in separate terminals at once.

Readline is fully used for history when support is compiled in.  This is less "dodgy" than the alternative ( :) ), and means things like `history_write_timestamps` can be used, which then makes multi-line commands work nicely even across es invocations.

Having a hook function makes it pretty easy to do things like imitate `HISTCONTROL` or even get fancier (unset `$history` and use a networked history server? Something like https://github.com/atuinsh/atuin?) I don't really need to waste bytes trying to convince _es_ people about how nice hook functions are, though.

Some caveats and alternatives to consider:

 - Bikeshedding `%write-history` and everything else is very welcome.  I don't know if that's the best name, but I'm too deep in the code at this point, so fresh eyes would be very helpful here.

 - Despite making it possible to enable `history_write_timestamps` with this change, I didn't do so, since it would make history files both different and a bit uglier.  We could turn this on now and make things extra shiny right away.

 - The behavior of `%write-history` without readline is a little less smart than before, because now it will just blindly create anything `$history` might be set to (and it won't unset its internal idea of `$history` on an error).  I'd try to make this work in-shell, but there's no way to open `O_APPEND` without also `O_CREAT`.  An alternative could be to keep `$&sethistory` and `$&writehistory` without readline, and have them just imitate the current behavior exactly.

 - In the opposite direction, `$&writehistory` could be modified to take the history file as an argument, as in: `$&writehistory [FILE] [COMMAND]`.  This could be used to get `$&sethistory` out of the shell.

 - `%write-history` is currently run before the command is executed, and there is no protection in `%interactive-loop` from it throwing an exception.  Therefore if you do something foolish like set `fn-%write-history = throw error %write-history`, you can just break your shell.  I didn't add any protection for this for the purposes of not growing `%interactive-loop` too much, but I do want to call out the omission.  We could also put the `%write-history` call after the command is executed.  I think it _should_ go before, but it would be a simpler fix than some fancy `unwind-protect` thing.

Hopefully the individual commit messages make it obvious what's going on in each file.