### PR TITLE
Fix syntax-handling bugs

### DIFF
--- a/closure.c
+++ b/closure.c
@@ -115,7 +115,7 @@ extern Closure *extractbindings(Tree *tree0) {
 	gcdisable();
 
 	if (tree->kind == nList && tree->u[1].p == NULL)
-		tree = tree->u[0].p; 
+		tree = tree->u[0].p;
 
 	me.closure = mkclosure(NULL, NULL);
 	me.next = chain;
@@ -126,12 +126,14 @@ extern Closure *extractbindings(Tree *tree0) {
 		while (tree->kind == nClosure) {
 			bindings = extract(tree->u[0].p, bindings);
 			tree = tree->u[1].p;
+			if (tree == NULL)
+				fail("$&parse", "null body in %%closure");
 			if (tree->kind == nList && tree->u[1].p == NULL)
-				tree = tree->u[0].p; 
+				tree = tree->u[0].p;
 		}
 
 	CatchException (e)
-	
+
 		chain = chain->next;
 		throw(e);
 

--- a/eval.c
+++ b/eval.c
@@ -414,9 +414,10 @@ restart:
 			EndExceptionHandler
 			break;
 		    case nList: {
-			list = glom(cp->tree, cp->binding, TRUE);
-			list = append(list, list->next);
+			Ref(List *, lp, glom(cp->tree, cp->binding, TRUE));
+			list = append(lp, list->next);
 			goto restart;
+			RefEnd(lp);
 		    }
 		    default:
 			panic("eval: bad closure node kind %d",

--- a/syntax.c
+++ b/syntax.c
@@ -268,7 +268,8 @@ extern Tree *mkmatch(Tree *subj, Tree *cases) {
 /* firstprepend -- insert a command node before its arg nodes after all redirections */
 extern Tree *firstprepend(Tree *first, Tree *args) {
 	Tree *t, **tp;
-	assert(first != NULL);
+	if (first == NULL)
+		return args;
 	for (t = args, tp = &args; t != NULL && t->kind == nRedir; t = *(tp = &t->CDR))
 		;
 	assert(t == NULL || t->kind == nList);


### PR DESCRIPTION
```
; '%closure ()'
```
was a segfault; now is a syntax error exception.  Fixes #68 

```
; () x
```
was an assertion error; now is not an error at all (the null term is just thrown away).  Fixes #63 

```
; let (n = '%closure (x = y) echo $x') {$n}
```
printed `y y` before; now correctly prints `y`.  Fixes #57 