### PR TITLE
Quote files which contain '.

### DIFF
--- a/input.c
+++ b/input.c
@@ -703,7 +703,7 @@ extern void initinput(void) {
 
 	rl_attempted_completion_function = builtin_completion;
 
-	rl_filename_quote_characters = " \t\n\\`$><=;|&{()}";
+	rl_filename_quote_characters = " \t\n\\`'$><=;|&{()}";
 	rl_filename_quoting_function = quote;
 	rl_filename_dequoting_function = unquote;
 #endif


### PR DESCRIPTION
I don't know how I missed this the first time around.  A file with a single quote character (') in it should be quoted.