### PR TITLE
Add AC_PROG_CPP to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ dnl saved_CFLAGS="$CFLAGS"
 
 dnl Checks for programs.
 AC_PROG_CC
+AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_MKDIR_P
 AC_PROG_YACC

--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,7 @@ AC_CACHE_CHECK(for files to extract signal information from,
 es_cv_sigfiles,
 AC_CMDSTDOUT_CPP(es_cv_sigfiles,
 [changequote(,)
-egrep '^#[ 	]+1[	 ]+' | sed 's/.*"\(.*\)".*/\1/' |sort -u |  
+grep -E '^#[ 	]+1[	 ]+' | sed 's/.*"\(.*\)".*/\1/' |sort -u |  
 grep '^/' |tr '\012' ' ' 
 changequote([,])],
 [#include <signal.h>], /usr/include/signal.h))


### PR DESCRIPTION
Fix building with autoconf 2.72.  Resolves #77, where more detail is provided on what this fix does.

This also swaps out `egrep` for `grep -E` in `./configure`, which shuts up a warning but doesn't actually make the fix happen.

Comparing `configure.ac` against the autoconf docs, I notice there's a lot of stuff in there that's "obsolescent".  Should we go through and clean up there?  Does it make sense to keep trying so hard to be portable that even the portability tool thinks it's too much?