### PR TITLE
Root exceptions during the varpop() calls in throw().

### DIFF
--- a/es.h
+++ b/es.h
@@ -444,7 +444,7 @@ extern Root *rootlist;
 
 extern void globalroot(void *addr);
 
-extern void exceptionroot(List **e);
+extern void exceptionroot(Root *, List **exceptionp);
 extern void exceptionunroot(void);
 
 /* struct Push -- varpush() placeholder */

--- a/es.h
+++ b/es.h
@@ -444,6 +444,9 @@ extern Root *rootlist;
 
 extern void globalroot(void *addr);
 
+extern void exceptionroot(List **e);
+extern void exceptionunroot(void);
+
 /* struct Push -- varpush() placeholder */
 
 struct Push {

--- a/except.c
+++ b/except.c
@@ -24,12 +24,14 @@ extern noreturn throw(List *e) {
 	assert(e != NULL);
 	assert(handler != NULL);
 	tophandler = handler->up;
-	
+
+	exceptionroot(&e);
 	while (pushlist != handler->pushlist) {
 		rootlist = &pushlist->defnroot;
 		varpop(pushlist);
 	}
 	evaldepth = handler->evaldepth;
+	exceptionunroot();
 
 #if ASSERTIONS
 	for (; rootlist != handler->rootlist; rootlist = rootlist->next)

--- a/except.c
+++ b/except.c
@@ -25,13 +25,16 @@ extern noreturn throw(List *e) {
 	assert(handler != NULL);
 	tophandler = handler->up;
 
-	exceptionroot(&e);
-	while (pushlist != handler->pushlist) {
-		rootlist = &pushlist->defnroot;
-		varpop(pushlist);
+	{
+		Root excroot;
+		exceptionroot(&excroot, &e);
+		while (pushlist != handler->pushlist) {
+			rootlist = &pushlist->defnroot;
+			varpop(pushlist);
+		}
+		exceptionunroot();
 	}
 	evaldepth = handler->evaldepth;
-	exceptionunroot();
 
 #if ASSERTIONS
 	for (; rootlist != handler->rootlist; rootlist = rootlist->next)

--- a/gc.c
+++ b/gc.c
@@ -301,13 +301,12 @@ extern void globalroot(void *addr) {
 }
 
 /* exceptionroot -- add an exception to the list of rooted exceptions */
-extern void exceptionroot(List **e) {
-	Root *root;
+extern void exceptionroot(Root *root, List **e) {
+	Root *r;
 #if ASSERTIONS
-	for (root = exceptionrootlist; root != NULL; root = root->next)
-		assert(root->p != (void **)e);
+	for (r = exceptionrootlist; r != NULL; r = r->next)
+		assert(r->p != (void **)e);
 #endif
-	root = ealloc(sizeof (Root));
 	root->p = (void **)e;
 	root->next = exceptionrootlist;
 	exceptionrootlist = root;
@@ -316,9 +315,7 @@ extern void exceptionroot(List **e) {
 /* exceptionunroot -- remove an exception from the list of rooted exceptions */
 extern void exceptionunroot(void) {
 	assert(exceptionrootlist != NULL);
-	Root *root = exceptionrootlist;
-	exceptionrootlist = root->next;
-	efree(root);
+	exceptionrootlist = exceptionrootlist->next;
 }
 
 /* not portable to word addressed machines */

--- a/var.c
+++ b/var.c
@@ -234,7 +234,7 @@ extern void varpush(Push *push, char *name, List *defn) {
 
 extern void varpop(Push *push) {
 	Var *var;
-	
+
 	assert(pushlist == push);
 	assert(rootlist == &push->defnroot);
 	assert(rootlist->next == &push->nameroot);


### PR DESCRIPTION
This fixes a (niche) class of memory unsafety.

We define a new root list to support this, because the two existing root lists won't work: rootlist is stack-oriented, while the e variable during throw() is being carried backwards through the stack; and globalrootlist (reasonably) has no mechanism for removing a root, which is necessary for the very ephemeral exception lists.

Fixes #85.