### PR TITLE
Fix panic when trying to eval concatted prims.

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -419,9 +419,15 @@ restart:
 			goto restart;
 			RefEnd(lp);
 		    }
-		    case nConcat:
-			/* only known to happen with primitives */
-			fail("es:eval", "invalid primitive: %E", list->term);
+		    case nConcat: {
+			Ref(Tree *, t, cp->tree);
+			while (t->kind == nConcat)
+				t = t->u[0].p;
+			if (t->kind == nPrim)
+				fail("es:eval", "invalid primitive name: %T", cp->tree);
+			RefEnd(t);
+			/* fallthrough */
+		    }
 		    default:
 			panic("eval: bad closure node kind %d",
 			      cp->tree->kind);

--- a/eval.c
+++ b/eval.c
@@ -420,7 +420,7 @@ restart:
 			RefEnd(lp);
 		    }
 		    case nConcat:
-			assert(cp->tree->u[0].p->kind == nPrim);
+			/* only known to happen with primitives */
 			fail("es:eval", "invalid primitive: %E", list->term);
 		    default:
 			panic("eval: bad closure node kind %d",

--- a/eval.c
+++ b/eval.c
@@ -419,6 +419,9 @@ restart:
 			goto restart;
 			RefEnd(lp);
 		    }
+		    case nConcat:
+			assert(cp->tree->u[0].p->kind == nPrim);
+			fail("es:eval", "invalid primitive: %E", list->term);
 		    default:
 			panic("eval: bad closure node kind %d",
 			      cp->tree->kind);


### PR DESCRIPTION
Fixes #5, I think.

Behavior without:
```
; $&a.
es panic: eval: bad closure node kind 3
```
Behavior with:
```
; $&a.
invalid primitive: $&a^.
```