### PR TITLE
Fixup compilation issues 

### DIFF
--- a/input.c
+++ b/input.c
@@ -276,7 +276,7 @@ stdgetenv(name)
 }
 
 char *
-getenv(char *name)
+getenv(const char *name)
 {
 	return realgetenv(name);
 }

--- a/input.h
+++ b/input.h
@@ -29,6 +29,7 @@ extern Input *input;
 extern void unget(Input *in, int c);
 extern Boolean disablehistory;
 extern void yyerror(char *s);
+void initgetenv(void);
 
 
 /* token.c */

--- a/var.c
+++ b/var.c
@@ -4,6 +4,7 @@
 #include "gc.h"
 #include "var.h"
 #include "term.h"
+#include "input.h"
 
 #if PROTECT_ENV
 #define	ENV_FORMAT	"%F=%W"


### PR DESCRIPTION
Use same signature as system getenv, so that new compilers don't fail.
Define the initgetenv in a header.