### PR TITLE
README.md: fix GitHub Pages url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ but all of the relevant information is mirrored in the repository and/or
 the website:
 
     http://www.github.com/wryun/es-shell
-    http://wryun.github.com/es-shell
+    http://wryun.github.io/es-shell
 
 including the change history and the old mailing list archives.
 


### PR DESCRIPTION
Should be:

https://wryun.github.io/es-shell/

not:

https://wryun.github.com/es-shell/