### PR TITLE
Compilation fixes

### DIFF
--- a/es.h
+++ b/es.h
@@ -285,7 +285,9 @@ extern Tree *parsestring(const char *str);
 extern void sethistory(char *file);
 extern Boolean isinteractive(void);
 #if ABUSED_GETENV
+#if READLINE
 extern void initgetenv(void);
+#endif
 #endif
 extern void initinput(void);
 extern void resetparser(void);

--- a/es.h
+++ b/es.h
@@ -284,6 +284,9 @@ extern Tree *parse(char *esprompt1, char *esprompt2);
 extern Tree *parsestring(const char *str);
 extern void sethistory(char *file);
 extern Boolean isinteractive(void);
+#if ABUSED_GETENV
+extern void initgetenv(void);
+#endif
 extern void initinput(void);
 extern void resetparser(void);
 
@@ -375,7 +378,7 @@ extern void gc(void);				/* provoke a collection, if enabled */
 extern void gcreserve(size_t nbytes);		/* provoke a collection, if enabled and not enough space */
 extern void gcenable(void);			/* enable collections */
 extern void gcdisable(void);			/* disable collections */
-extern Boolean gcisblocked();			/* is collection disabled? */
+extern Boolean gcisblocked(void);		/* is collection disabled? */
 
 
 /*

--- a/input.c
+++ b/input.c
@@ -618,7 +618,7 @@ static List *(*wordslistgen)(char *);
 static char *list_completion_function(const char *text, int state) {
 	static char **matches = NULL;
 	static int matches_idx, matches_len;
-	int rlen;
+	int i, rlen;
 	char *result;
 
 	const int pfx_len = strlen(complprefix);
@@ -637,7 +637,7 @@ static char *list_completion_function(const char *text, int state) {
 
 	rlen = strlen(matches[matches_idx]);
 	result = ealloc(rlen + pfx_len + 1);
-	for (int i = 0; i < pfx_len; i++)
+	for (i = 0; i < pfx_len; i++)
 		result[i] = complprefix[i];
 	strcpy(&result[pfx_len], matches[matches_idx]);
 	result[rlen + pfx_len] = '\0';

--- a/input.c
+++ b/input.c
@@ -255,8 +255,7 @@ static char *esgetenv(const char *name) {
 }
 
 static char *
-stdgetenv(name)
-	register const char *name;
+stdgetenv(register const char *name)
 {
 	extern char **environ;
 	register int len;
@@ -276,7 +275,7 @@ stdgetenv(name)
 }
 
 char *
-getenv(char *name)
+getenv(const char *name)
 {
 	return realgetenv(name);
 }

--- a/input.c
+++ b/input.c
@@ -255,7 +255,7 @@ static char *esgetenv(const char *name) {
 }
 
 static char *
-stdgetenv(register const char *name)
+stdgetenv(const char *name)
 {
 	extern char **environ;
 	register int len;

--- a/syntax.c
+++ b/syntax.c
@@ -234,6 +234,9 @@ extern Tree *redirappend(Tree *tree, Tree *r) {
 
 /* mkmatch -- rewrite match as appropriate if with ~ commands */
 extern Tree *mkmatch(Tree *subj, Tree *cases) {
+	const char *varname = "matchexpr";
+	Tree *matches = NULL;
+	Tree *sass, *svar;
 	/*
 	 * Empty match -- with no patterns to match the subject,
 	 * it's like saying {if}, which simply returns true.
@@ -246,16 +249,15 @@ extern Tree *mkmatch(Tree *subj, Tree *cases) {
 	 * repeatedly by assigning it to a temporary variable and using that
 	 * variable as the first argument to '~' .
 	 */
-	const char *varname = "matchexpr";
-	Tree *sass = treecons2(mk(nAssign, mk(nWord, varname), subj), NULL);
-	Tree *svar = mk(nVar, mk(nWord, varname));
-	Tree *matches = NULL;
+	sass = treecons2(mk(nAssign, mk(nWord, varname), subj), NULL);
+	svar = mk(nVar, mk(nWord, varname));
 	for (; cases != NULL; cases = cases->CDR) {
+		Tree *match;
 		Tree *pattlist = cases->CAR->CAR;
 		Tree *cmd = cases->CAR->CDR;
 		if (pattlist != NULL && pattlist->kind != nList)
 			pattlist = treecons(pattlist, NULL);
-		Tree *match = treecons(
+		match = treecons(
 			thunkify(mk(nMatch, svar, pattlist)),
 			treecons(cmd, NULL)
 		);


### PR DESCRIPTION
Some declarations appeared after executable code in both #59 and #36, which caused issues for compilers that don't support that C99 feature.

Newer compilers on modern systems may complain about the K&R-style getenv replacement code when it's enabled, mainly because of the lack of const-correctness since K&R lacked a `const` keyword.
Nobody uses K&R anymore, and K&R-style function declarations and definitions have been dropped entirely as of C23 as well, so everything gets proper prototypes and function definitions, including gcisblocked() in es.h.
Also, implicit function declarations were removed in C99, so a prototype for initgetenv() has been added to es.h for compatibility.