### PR TITLE
`%read` in chunks for lseek()able files.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,8 +94,8 @@ AC_PROG_GCC_TRADITIONAL
 AC_FUNC_MMAP
 
 AC_FUNC_WAIT3
-AC_CHECK_FUNCS(strerror strtol lstat setrlimit sigrelse sighold sigaction \
-sysconf setsid sigsetjmp)
+AC_CHECK_FUNCS(strerror strtol lseek lstat setrlimit sigrelse sighold \
+sigaction sysconf setsid sigsetjmp)
 
 AC_CACHE_CHECK(for an abused getenv, es_cv_abused_getenv,
 AC_RUN_IFELSE([AC_LANG_SOURCE([[


### PR DESCRIPTION
This is a performance optimization that's normally insignificant; occasionally good, in tight `%read` loops; and very rarely negative, when those tight `%read` loops work on a file with mostly zero-to-one character lines.  Generally the performance improvement increases as line lengths increase, which shouldn't be a surprise.  Files with _pretty_ short lines, like `/usr/share/dict/words`, see a measurable improvement with tight `%read` loops, though.

In theory, it seems to me the overhead of the extra `lseek()` calls (which are the source of the negative effects, where they appear) could be reduced by caching the seekability of fds.  Maybe just one such value, assuming performance-sensitive calls to `%read` are typically done repeatedly in a loop (and on a single fd).

This introduces an awkward performance asymmetry, sadly, between the cases of `cat foo | the_script` and `the_script < foo` , since stdin in the former case is non-seekable from a pipe, while in the latter case it's seekable.

I'm not married to this proposal.  Just wanted to put it out there.  I'm not very good at speedy code so there's very possibly a better way to do this than I've got here :)