### PR TITLE
Fix /signal handling with readline

### DIFF
--- a/input.c
+++ b/input.c
@@ -298,9 +298,12 @@ static int fdfill(Input *in) {
 
 #if READLINE
 	if (in->runflags & run_interactive && in->fd == 0) {
-		char *rlinebuf = callreadline(prompt);
-		if (rlinebuf == NULL)
+		char *rlinebuf = NULL;
+		do {
+			rlinebuf = callreadline(prompt);
+		} while (rlinebuf == NULL && errno == EINTR);
 
+		if (rlinebuf == NULL)
 			nread = 0;
 		else {
 			if (*rlinebuf != '\0')


### PR DESCRIPTION
Fixes #111.

Previously, signals received but not triggering an exception (so, signals handled with the `sig_noop` handler) at the prompt would cause the shell to exit on an `eof` exception.  This is a minimal fix for that.