### PR TITLE
Do not die when reading incomplete heredocs

### DIFF
--- a/heredoc.c
+++ b/heredoc.c
@@ -43,6 +43,7 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 		yyerror("here document eof-marker contains a newline");
 		return NULL;
 	}
+	ignoreeof = TRUE;
 	disablehistory = TRUE;
 
 	for (tree = NULL, tailp = &tree, buf = openbuffer(0);;) {
@@ -63,6 +64,7 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 			if (c == EOF) {
 				yyerror("incomplete here document");
 				freebuffer(buf);
+				ignoreeof = FALSE;
 				disablehistory = FALSE;
 				return NULL;
 			}
@@ -78,6 +80,7 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 				var = getherevar();
 				if (var == NULL) {
 					freebuffer(buf);
+					ignoreeof = FALSE;
 					disablehistory = FALSE;
 					return NULL;
 				}
@@ -92,6 +95,7 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 		}
 	}
 
+	ignoreeof = FALSE;
 	disablehistory = FALSE;
 	return tree->CDR == NULL ? tree->CAR : tree;
 }

--- a/input.c
+++ b/input.c
@@ -329,7 +329,7 @@ static int fdfill(Input *in) {
 	} while (nread == -1 && errno == EINTR);
 
 	if (nread <= 0) {
-		if (nread == 0 && !ignoreeof) {
+		if (!ignoreeof) {
 			close(in->fd);
 			in->fd = -1;
 			in->fill = eoffill;

--- a/input.c
+++ b/input.c
@@ -27,6 +27,7 @@ Input *input;
 char *prompt, *prompt2;
 
 Boolean disablehistory = FALSE;
+Boolean ignoreeof = FALSE;
 Boolean resetterminal = FALSE;
 static char *history;
 static int historyfd = -1;
@@ -328,10 +329,12 @@ static int fdfill(Input *in) {
 	} while (nread == -1 && errno == EINTR);
 
 	if (nread <= 0) {
-		close(in->fd);
-		in->fd = -1;
-		in->fill = eoffill;
-		in->runflags &= ~run_interactive;
+		if (nread == 0 && !ignoreeof) {
+			close(in->fd);
+			in->fd = -1;
+			in->fill = eoffill;
+			in->runflags &= ~run_interactive;
+		}
 		if (nread == -1)
 			fail("$&parse", "%s: %s", in->name == NULL ? "es" : in->name, esstrerror(errno));
 		return EOF;

--- a/input.h
+++ b/input.h
@@ -28,6 +28,7 @@ struct Input {
 extern Input *input;
 extern void unget(Input *in, int c);
 extern Boolean disablehistory;
+extern Boolean ignoreeof;
 extern void yyerror(char *s);
 
 


### PR DESCRIPTION
Fixes #100.

This simple version works both when sending a ^D while reading a heredoc at the interactive loop, and when falling off the end of a shell script while reading a heredoc.