### PR TITLE
Clear eval_exitonfalse when setting up a new input stream.

### DIFF
--- a/input.c
+++ b/input.c
@@ -418,8 +418,10 @@ extern List *runinput(Input *in, int runflags) {
 	          = varlookup(dispatcher[((flags & run_printcmds) ? 1 : 0)
 					 + ((flags & run_noexec) ? 2 : 0)],
 			      NULL);
-		if (flags & eval_exitonfalse)
+		if (flags & eval_exitonfalse) {
 			dispatch = mklist(mkstr("%exit-on-false"), dispatch);
+			flags &= ~eval_exitonfalse;
+		}
 		varpush(&push, "fn-%dispatch", dispatch);
 
 		repl = varlookup((flags & run_interactive)


### PR DESCRIPTION
This causes %exit-on-false, as part of %dispatch, to be the actual trigger for the exit-on-false behavior.  The implementation context strongly implies that the current behavior is a bug.  (Why would we use %exit-on-false, whose only job is to set eval_exitonfalse to 1, and also just leave eval_exitonfalse as 1 ourselves?  Why would we explicitly call `$fn-%dispatch false` in the `error` exception handler if we expected a simple call to `false` to exit the shell too?)

This also makes using `es -e` with any kind of overriden REPL much easier, because %prompt and other REPL hooks can no longer trigger the exit-on-false behavior.

This is one part of #73, but because this part is almost definitely just a bug, while the rest is more about design improvements, I am merging this part more unilaterally.