### PR TITLE
Fix --without-readline and link with curses/terminfo/termcap correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@ autom4te.cache
 /missing
 /stamp-h1
 /ltmain.sh
+/m4/libtool.m4
+/m4/ltoptions.m4
+/m4/ltsugar.m4
+/m4/ltversion.m4
+/m4/lt~obsolete.m4
+/config.h.in~
+/configure~
 
 Makefile
 config.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -44,9 +44,9 @@ MKDIR_P = @MKDIR_P@
 ## Bison is generating incorrect parsers.  So do not use, for now
 # YACC = @YACC@
 
-CFLAGS	= $(ADDCFLAGS) -I. -I$(srcdir) -W -Wall -Wdeclaration-after-statement -Wno-clobbered @CFLAGS@
+CFLAGS	= $(ADDCFLAGS) -I. -I$(srcdir) -W -Wall -Wdeclaration-after-statement -Wno-clobbered @READLINE_CFLAGS@ @CFLAGS@
 LDFLAGS	= $(ADDLDFLAGS) @LDFLAGS@
-LIBS	= $(ADDLIBS) @LIBS@
+LIBS	= $(ADDLIBS) @READLINE_LIBS@ @LIBS@
 
 VPATH = $(srcdir)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,9 @@
 dnl Process this file with autoconf to produce a configure script.
+AC_PREREQ([2.64])
 AC_INIT
 AC_CONFIG_SRCDIR([access.c])
-AC_CONFIG_HEADER(config.h)
-
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIR([m4])
 
 dnl AC_CMDSTDOUT_CPP(variable, command, headers)
 AC_DEFUN([AC_CMDSTDOUT_CPP],
@@ -15,13 +16,6 @@ $1=`(eval "$ac_cpp conftest.$ac_ext") 2>&AS_MESSAGE_LOG_FD | $2`
 rm -f conftest*
 ])
 
-
-use_readline=yes
-use_editline=no
-
-AC_ARG_WITH(readline,
---with-readline		Use GNU Readline, use_readline=yes)
-
 AC_CANONICAL_HOST
 
 case "$host" in
@@ -30,16 +24,12 @@ case "$host" in
 	;;
 esac
 
-dnl saved_CFLAGS="$CFLAGS"
-
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_MKDIR_P
 AC_PROG_YACC
-
-dnl CFLAGS="$CFLAGS $saved_CFLAGS"
 
 dnl ----------------------------
 dnl CHECK FOR /dev/fd FILESYSTEM
@@ -61,20 +51,7 @@ dnl Checks for libraries.
 
 AC_CHECK_LIB(sun, getpwuid)
 
-if test "$use_readline" = yes || test "$use_editline" = yes
-then
-	AC_CHECK_LIB(terminfo, main)
-	AC_CHECK_LIB(termcap, main)
-	if test "$use_readline" = yes
-	then
-		AC_CHECK_LIB(readline, readline)
-	elif test "$use_editline" = yes
-	then
-		AC_CHECK_LIB(edit, readline)
-	fi
-
-fi
-
+ES_WITH_READLINE
 
 dnl Checks for header files.
 AC_HEADER_DIRENT

--- a/doc/es.1
+++ b/doc/es.1
@@ -2732,9 +2732,7 @@ is if
 .I es
 is compiled with support for the
 .I readline
-or
-.I editline
-libraries.
+library.
 It is used in the implementation of settor functions of the
 .Cr TERM
 and

--- a/es.h
+++ b/es.h
@@ -285,7 +285,7 @@ extern Tree *parsestring(const char *str);
 extern void sethistory(char *file);
 extern Boolean isinteractive(void);
 #if ABUSED_GETENV
-#if READLINE
+#if HAVE_READLINE
 extern void initgetenv(void);
 #endif
 #endif
@@ -302,7 +302,7 @@ extern List *runstring(const char *str, const char *name, int flags);
 #define	run_printcmds		32	/* -x */
 #define	run_lisptrees		64	/* -L and defined(LISPTREES) */
 
-#if READLINE
+#if HAVE_READLINE
 extern Boolean resetterminal;
 #endif
 

--- a/esconfig.h
+++ b/esconfig.h
@@ -96,9 +96,6 @@
  *		that is, makes sure no characters other than c identifier
  *		characters appear in them.
  *
- *	READLINE
- *		true if es is being linked with editline or gnu readline.
- *
  *	REF_ASSERTIONS
  *		if this is on, assertions about the use of the Ref() macro
  *		will be checked at run-time.  this is only useful if you're
@@ -184,10 +181,6 @@
 
 #if HAVE_SIGRELSE && HAVE_SIGHOLD
 # define SYSV_SIGNALS 1
-#endif
-
-#if HAVE_LIBREADLINE
-# define READLINE 1
 #endif
 
 /* NeXT defaults */
@@ -318,10 +311,6 @@
 
 #ifndef	PROTECT_ENV
 #define	PROTECT_ENV		1
-#endif
-
-#ifndef	READLINE
-#define	READLINE		0
 #endif
 
 #ifndef	REF_ASSERTIONS

--- a/initial.es
+++ b/initial.es
@@ -712,8 +712,8 @@ set-noexport		= $&setnoexport
 set-max-eval-depth	= $&setmaxevaldepth
 
 #	If the primitive $&resetterminal is defined (meaning that readline
-#	or editline is being used), setting the variables $TERM or $TERMCAP
-#	should notify the line editor library.
+#	is being used), setting the variables $TERM or $TERMCAP should
+#	notify the line editor library.
 
 if {~ <=$&primitives resetterminal} {
 	set-TERM	= @ { $&resetterminal; result $* }

--- a/input.c
+++ b/input.c
@@ -32,7 +32,7 @@ Boolean resetterminal = FALSE;
 static char *history;
 static int historyfd = -1;
 
-#if READLINE
+#if HAVE_READLINE
 #include <readline/readline.h>
 extern void add_history(char *);
 extern int read_history(char *);
@@ -116,7 +116,7 @@ extern void sethistory(char *file) {
 		close(historyfd);
 		historyfd = -1;
 	}
-#if READLINE
+#if HAVE_READLINE
 	/* Attempt to populate readline history with new history file. */
 	stifle_history(50000); /* Keep memory usage within sane-ish bounds. */
 	read_history(file);
@@ -198,7 +198,7 @@ static int eoffill(Input *in) {
 	return EOF;
 }
 
-#if READLINE
+#if HAVE_READLINE
 /* callreadline -- readline wrapper */
 static char *callreadline(char *prompt) {
 	char *r;
@@ -291,7 +291,7 @@ initgetenv(void)
 
 #endif /* ABUSED_GETENV */
 
-#endif	/* READLINE */
+#endif	/* HAVE_READLINE */
 
 /* fdfill -- fill input buffer by reading from a file descriptor */
 static int fdfill(Input *in) {
@@ -299,7 +299,7 @@ static int fdfill(Input *in) {
 	assert(in->buf == in->bufend);
 	assert(in->fd >= 0);
 
-#if READLINE
+#if HAVE_READLINE
 	if (in->runflags & run_interactive && in->fd == 0) {
 		char *rlinebuf = NULL;
 		do {
@@ -364,7 +364,7 @@ extern Tree *parse(char *pr1, char *pr2) {
 	if (ISEOF(input))
 		throw(mklist(mkstr("eof"), NULL));
 
-#if READLINE
+#if HAVE_READLINE
 	prompt = (pr1 == NULL) ? "" : pr1;
 #else
 	if (pr1 != NULL)
@@ -584,7 +584,7 @@ extern Boolean isinteractive(void) {
 /*
  * readline integration.
  */
-#if READLINE
+#if HAVE_READLINE
 /* quote -- teach readline how to quote a word in es during completion */
 static char *quote(char *text, int type, char *qp) {
 	char *p, *r;
@@ -678,7 +678,7 @@ char **builtin_completion(const char *text, int unused start, int unused end) {
 
 	return matches;
 }
-#endif /* READLINE */
+#endif /* HAVE_READLINE */
 
 
 /*
@@ -701,7 +701,7 @@ extern void initinput(void) {
 	/* call the parser's initialization */
 	initparse();
 
-#if READLINE
+#if HAVE_READLINE
 	rl_readline_name = "es";
 
 	/* these two word_break_characters exclude '&' due to primitive completion */

--- a/m4/readline.m4
+++ b/m4/readline.m4
@@ -1,0 +1,120 @@
+# _ES_CHECK_READLINE([CFLAGS], [LIBS], [ACTION-IF-SUCCESS], [ACTION-IF-FAILURE])
+# ------------------------------------------------------------------------------
+# Any CFLAGS provided are cached in es_cv_readline_cflags if it isn't already set.
+# The first working library combination is cached in es_cv_readline_libs.
+AC_DEFUN([_ES_CHECK_READLINE], [
+AC_REQUIRE([AC_PROG_CC])dnl
+AS_VAR_COPY([saved_CFLAGS], [CFLAGS])
+AS_VAR_COPY([saved_LIBS], [LIBS])
+AS_VAR_APPEND([CFLAGS], [" $es_cv_readline_cflags"])
+AC_LANG_CONFTEST([AC_LANG_PROGRAM([[
+#include <stdio.h>
+#include <readline/readline.h>
+#include <readline/history.h>
+]], [[
+char *line = readline("prompt> ");
+if (!line) add_history(line);
+return line != (char *)0;
+]])])
+AC_CACHE_CHECK([for readline libraries], [es_cv_readline_libs], [
+AS_IF([test -n "$2"], [
+  AS_VAR_APPEND([LIBS], [" $2"])
+  AC_LINK_IFELSE([],
+                 [AS_VAR_SET([es_cv_readline_libs], ["$2"])],
+                 [AS_VAR_SET([es_cv_readline_libs], [no])])
+], [
+dnl The m4_foreach macro expands into what is effectively an unrolled loop.
+dnl It can make Autoconf time slightly longer, but it means configure can be faster.
+m4_foreach([TERMLIB], [,curses,tinfo,terminfo,termcap], [
+  AS_VAR_SET_IF([es_cv_readline_libs], [
+  ], [
+    m4_pushdef([es_Rllibs], [-lreadline]m4_ifval(TERMLIB, [ -l]TERMLIB))dnl
+    AS_VAR_COPY([LIBS], [saved_LIBS])
+    AS_VAR_APPEND([LIBS], [" ]es_Rllibs["])
+    AC_LINK_IFELSE([], [AS_VAR_SET([es_cv_readline_libs], ["[]es_Rllibs[]"])])
+    m4_popdef([es_Rllibs])dnl
+  ])
+])dnl
+AS_VAR_SET_IF([es_cv_readline_libs],
+              [],
+              [AS_VAR_SET([es_cv_readline_libs], [no])])
+])
+])
+rm -f conftest.$ac_ext
+AS_VAR_COPY([LIBS], [saved_LIBS])
+AS_VAR_COPY([CFLAGS], [saved_CFLAGS])
+AS_VAR_IF([es_cv_readline_libs], [no], [$4], [$3])
+])# _ES_CHECK_READLINE
+
+# ES_CHECK_READLINE([CFLAGS], [LIBS], [ACTION-IF-SUCCESS], [ACTION-IF-FAILURE])
+# -----------------------------------------------------------------------------
+# Verify that a program using readline functions and headers successfully compiles and links.
+# Required/desired compiler flags may be specified in the first argument and will be cached in es_cv_readline_cflags.
+# Similarly, -l'library' arguments for linking may be specified in the second argument.
+#
+# If the list of libraries is empty, linking is attempted using -lreadline alone.
+# If linking fails, additional attempts are tried with one of the following terminal capability library arguments appended:
+# - tinfow
+# - tinfo
+# - terminfo
+# - termcapw
+# - termcap
+#
+# If linking fails after all attempts, es_cv_readline_libs is set to "no", and ACTION-IF-FAILURE is executed.
+# Otherwise, es_cv_readline_libs contains the required libraries, the HAVE_READLINE preprocessor macro is defined, and ACTION-IF-SUCCESS is executed.
+AC_DEFUN([ES_CHECK_READLINE], [
+_ES_CHECK_READLINE($@)
+AS_VAR_IF([es_cv_readline_libs], [no], [
+  # Ensure we don't attempt to link es with readline.
+  AC_SUBST([READLINE_CFLAGS], [])
+  AC_SUBST([READLINE_LIBS], [])
+], [
+  AC_DEFINE([HAVE_READLINE], [1], [Define to 1 if you have readline.])
+  AC_SUBST([READLINE_CFLAGS], [$es_cv_readline_cflags])
+  AC_SUBST([READLINE_LIBS], [$es_cv_readline_libs])
+])
+])# ES_CHECK_READLINE
+
+# ES_WITH_READLINE([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE])
+# ----------------------------------------------------------
+# A simplified version of ES_CHECK_READLINE that additionally creates a --with-readline configure flag.
+#
+# Two precious variables, READLINE_CFLAGS and READLINE_LIBS, are also supported.
+# The value of READLINE_CFLAGS is passed as the CFLAGS argument to ES_CHECK_READLINE.
+# Similarly, READLINE_LIBS is the LIBS argument to ES_CHECK_READLINE.
+# These are substituted into the generated Makefile.
+#
+# By default, if readline support is required using --with-readline=yes and ES_CHECK_READLINE fails, ACTION-IF-FAILURE uses AC_MSG_ERROR to terminate configure with an error message.
+AC_DEFUN([ES_WITH_READLINE], [
+AC_ARG_WITH([readline],
+            [AS_HELP_STRING([--with-readline],
+                            [build with readline support @<:@default=check@:>@])],
+            [],
+            [AS_VAR_SET([with_readline], [check])])
+AC_ARG_VAR([READLINE_CFLAGS], [C compiler flags for readline])
+AC_ARG_VAR([READLINE_LIBS], [linker flags for readline])
+
+AS_IF([AS_VAR_TEST_SET([READLINE_CFLAGS])],
+      [AS_VAR_COPY([es_cv_readline_cflags], [READLINE_CFLAGS])])
+
+m4_pushdef([ES_REQUIRED_ERROR],
+           [AC_MSG_FAILURE([readline support requested but unavailable])])dnl
+m4_pushdef([ES_DEFAULT_ACTIONS_IF_REQUIRED],
+           m4_dquote(m4_case([$#],
+                             [0], [[], ES_REQUIRED_ERROR],
+                             [1], [[$1], ES_REQUIRED_ERROR],
+                             [[$1], [$2]])))dnl
+m4_popdef([ES_REQUIRED_ERROR])dnl
+
+AS_CASE(["$with_readline"],
+        [no],         [],
+        [auto|check], [ES_CHECK_READLINE([$es_cv_readline_cflags],
+                                         [${READLINE_LIBS-}],
+                                         [$1], [$2])],
+        [yes],        [ES_CHECK_READLINE([$es_cv_readline_cflags],
+                                         [${READLINE_LIBS-}],
+                                         ES_DEFAULT_ACTIONS_IF_REQUIRED)],
+        [AC_MSG_ERROR([--with-readline: valid values are "yes", "no", "check" -- got "$with_readline"])])
+
+m4_popdef([ES_DEFAULT_ACTIONS_IF_REQUIRED])dnl
+])# ES_WITH_READLINE

--- a/m4/readline.m4
+++ b/m4/readline.m4
@@ -3,47 +3,53 @@
 # Any CFLAGS provided are cached in es_cv_readline_cflags if it isn't already set.
 # The first working library combination is cached in es_cv_readline_libs.
 AC_DEFUN([_ES_CHECK_READLINE], [
-AC_REQUIRE([AC_PROG_CC])dnl
-AS_VAR_COPY([saved_CFLAGS], [CFLAGS])
-AS_VAR_COPY([saved_LIBS], [LIBS])
-AS_VAR_APPEND([CFLAGS], [" $es_cv_readline_cflags"])
-AC_LANG_CONFTEST([AC_LANG_PROGRAM([[
+  AC_REQUIRE([AC_PROG_CC])dnl
+  AS_VAR_COPY([saved_CFLAGS], [CFLAGS])
+  AS_VAR_COPY([saved_LIBS], [LIBS])
+  AS_IF([test -n "$1"], [
+    AS_VAR_SET([es_cv_readline_cflags], ["$1"])
+    AS_VAR_APPEND([CFLAGS], [" $es_cv_readline_cflags"])
+  ])
+  AC_LANG_CONFTEST([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <readline/readline.h>
 #include <readline/history.h>
-]], [[
-char *line = readline("prompt> ");
-if (!line) add_history(line);
-return line != (char *)0;
-]])])
-AC_CACHE_CHECK([for readline libraries], [es_cv_readline_libs], [
-AS_IF([test -n "$2"], [
-  AS_VAR_APPEND([LIBS], [" $2"])
-  AC_LINK_IFELSE([],
-                 [AS_VAR_SET([es_cv_readline_libs], ["$2"])],
-                 [AS_VAR_SET([es_cv_readline_libs], [no])])
-], [
-dnl The m4_foreach macro expands into what is effectively an unrolled loop.
-dnl It can make Autoconf time slightly longer, but it means configure can be faster.
-m4_foreach([TERMLIB], [,curses,tinfo,terminfo,termcap], [
-  AS_VAR_SET_IF([es_cv_readline_libs], [
-  ], [
-    m4_pushdef([es_Rllibs], [-lreadline]m4_ifval(TERMLIB, [ -l]TERMLIB))dnl
-    AS_VAR_COPY([LIBS], [saved_LIBS])
-    AS_VAR_APPEND([LIBS], [" ]es_Rllibs["])
-    AC_LINK_IFELSE([], [AS_VAR_SET([es_cv_readline_libs], ["[]es_Rllibs[]"])])
-    m4_popdef([es_Rllibs])dnl
+  ]], [[
+    char *line = readline("prompt> ");
+    if (!line) add_history(line);
+    return line != (char *)0;
+  ]])])
+  AC_CACHE_CHECK([for readline libraries], [es_cv_readline_libs], [
+    AS_IF([test -n "$2"], [
+      AS_VAR_APPEND([LIBS], [" $2"])
+      AC_LINK_IFELSE([], [
+        AS_VAR_SET([es_cv_readline_libs], ["$2"])
+      ], [
+        AS_VAR_SET([es_cv_readline_libs], [no])
+      ])
+    ], [
+      dnl The m4_foreach macro expands into what is effectively an unrolled loop.
+      dnl It can make Autoconf time slightly longer, but it means configure can be faster.
+      m4_foreach([TERMLIB], [,curses,tinfo,ncurses,terminfo,termcap], [
+        AS_VAR_SET_IF([es_cv_readline_libs], [
+        ], [
+          m4_pushdef([es_Rllibs], [-lreadline]m4_ifval(TERMLIB, [ -l]TERMLIB))dnl
+          AS_VAR_COPY([LIBS], [saved_LIBS])
+          AS_VAR_APPEND([LIBS], [" ]es_Rllibs["])
+          AC_LINK_IFELSE([], [AS_VAR_SET([es_cv_readline_libs], ["[]es_Rllibs[]"])])
+          m4_popdef([es_Rllibs])dnl
+        ])
+      ])dnl
+      AS_VAR_SET_IF([es_cv_readline_libs], [
+      ], [
+        AS_VAR_SET([es_cv_readline_libs], [no])
+      ])
+    ])
   ])
-])dnl
-AS_VAR_SET_IF([es_cv_readline_libs],
-              [],
-              [AS_VAR_SET([es_cv_readline_libs], [no])])
-])
-])
-rm -f conftest.$ac_ext
-AS_VAR_COPY([LIBS], [saved_LIBS])
-AS_VAR_COPY([CFLAGS], [saved_CFLAGS])
-AS_VAR_IF([es_cv_readline_libs], [no], [$4], [$3])
+  rm -f conftest.$ac_ext
+  AS_VAR_COPY([LIBS], [saved_LIBS])
+  AS_VAR_COPY([CFLAGS], [saved_CFLAGS])
+  AS_VAR_IF([es_cv_readline_libs], [no], [$4], [$3])
 ])# _ES_CHECK_READLINE
 
 # ES_CHECK_READLINE([CFLAGS], [LIBS], [ACTION-IF-SUCCESS], [ACTION-IF-FAILURE])
@@ -54,25 +60,24 @@ AS_VAR_IF([es_cv_readline_libs], [no], [$4], [$3])
 #
 # If the list of libraries is empty, linking is attempted using -lreadline alone.
 # If linking fails, additional attempts are tried with one of the following terminal capability library arguments appended:
-# - tinfow
+# - curses
 # - tinfo
 # - terminfo
-# - termcapw
 # - termcap
 #
 # If linking fails after all attempts, es_cv_readline_libs is set to "no", and ACTION-IF-FAILURE is executed.
 # Otherwise, es_cv_readline_libs contains the required libraries, the HAVE_READLINE preprocessor macro is defined, and ACTION-IF-SUCCESS is executed.
 AC_DEFUN([ES_CHECK_READLINE], [
-_ES_CHECK_READLINE($@)
-AS_VAR_IF([es_cv_readline_libs], [no], [
-  # Ensure we don't attempt to link es with readline.
-  AC_SUBST([READLINE_CFLAGS], [])
-  AC_SUBST([READLINE_LIBS], [])
-], [
-  AC_DEFINE([HAVE_READLINE], [1], [Define to 1 if you have readline.])
-  AC_SUBST([READLINE_CFLAGS], [$es_cv_readline_cflags])
-  AC_SUBST([READLINE_LIBS], [$es_cv_readline_libs])
-])
+  _ES_CHECK_READLINE($@)
+  AS_VAR_IF([es_cv_readline_libs], [no], [
+    # Ensure we don't attempt to link es with readline.
+    AC_SUBST([READLINE_CFLAGS], [])
+    AC_SUBST([READLINE_LIBS], [])
+  ], [
+    AC_DEFINE([HAVE_READLINE], [1], [Define to 1 if you have readline.])
+    AC_SUBST([READLINE_CFLAGS], [${es_cv_readline_cflags-}])
+    AC_SUBST([READLINE_LIBS], [$es_cv_readline_libs])
+  ])
 ])# ES_CHECK_READLINE
 
 # ES_WITH_READLINE([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE])
@@ -86,35 +91,36 @@ AS_VAR_IF([es_cv_readline_libs], [no], [
 #
 # By default, if readline support is required using --with-readline=yes and ES_CHECK_READLINE fails, ACTION-IF-FAILURE uses AC_MSG_ERROR to terminate configure with an error message.
 AC_DEFUN([ES_WITH_READLINE], [
-AC_ARG_WITH([readline],
-            [AS_HELP_STRING([--with-readline],
-                            [build with readline support @<:@default=check@:>@])],
-            [],
-            [AS_VAR_SET([with_readline], [check])])
-AC_ARG_VAR([READLINE_CFLAGS], [C compiler flags for readline])
-AC_ARG_VAR([READLINE_LIBS], [linker flags for readline])
+  AC_ARG_WITH([readline],
+              [AS_HELP_STRING([--with-readline],
+                              [build with readline support @<:@default=check@:>@])],
+              [],
+              [AS_VAR_SET([with_readline], [check])])
+  AC_ARG_VAR([READLINE_CFLAGS], [C compiler flags for readline])
+  AC_ARG_VAR([READLINE_LIBS], [linker flags for readline])
 
-AS_IF([AS_VAR_TEST_SET([READLINE_CFLAGS])],
-      [AS_VAR_COPY([es_cv_readline_cflags], [READLINE_CFLAGS])])
+  AS_IF([AS_VAR_TEST_SET([READLINE_CFLAGS])], [
+    AS_VAR_COPY([es_cv_readline_cflags], [READLINE_CFLAGS])
+  ])
 
-m4_pushdef([ES_REQUIRED_ERROR],
-           [AC_MSG_FAILURE([readline support requested but unavailable])])dnl
-m4_pushdef([ES_DEFAULT_ACTIONS_IF_REQUIRED],
-           m4_dquote(m4_case([$#],
-                             [0], [[], ES_REQUIRED_ERROR],
-                             [1], [[$1], ES_REQUIRED_ERROR],
-                             [[$1], [$2]])))dnl
-m4_popdef([ES_REQUIRED_ERROR])dnl
+  m4_pushdef([ES_REQUIRED_ERROR],
+             [AC_MSG_FAILURE([readline support requested but unavailable])])dnl
+  m4_pushdef([ES_DEFAULT_ACTIONS_IF_REQUIRED],
+             m4_dquote(m4_case([$#],
+                               [0], [[], ES_REQUIRED_ERROR],
+                               [1], [[$1], ES_REQUIRED_ERROR],
+                               [[$1], [$2]])))dnl
+  m4_popdef([ES_REQUIRED_ERROR])dnl
 
-AS_CASE(["$with_readline"],
-        [no],         [],
-        [auto|check], [ES_CHECK_READLINE([$es_cv_readline_cflags],
-                                         [${READLINE_LIBS-}],
-                                         [$1], [$2])],
-        [yes],        [ES_CHECK_READLINE([$es_cv_readline_cflags],
-                                         [${READLINE_LIBS-}],
-                                         ES_DEFAULT_ACTIONS_IF_REQUIRED)],
-        [AC_MSG_ERROR([--with-readline: valid values are "yes", "no", "check" -- got "$with_readline"])])
+  AS_CASE(["$with_readline"],
+          [no],         [],
+          [auto|check], [ES_CHECK_READLINE([$es_cv_readline_cflags],
+                                           [${READLINE_LIBS-}],
+                                           [$1], [$2])],
+          [yes],        [ES_CHECK_READLINE([$es_cv_readline_cflags],
+                                           [${READLINE_LIBS-}],
+                                           ES_DEFAULT_ACTIONS_IF_REQUIRED)],
+          [AC_MSG_ERROR([--with-readline: valid values are "yes", "no", "check" -- got "$with_readline"])])
 
-m4_popdef([ES_DEFAULT_ACTIONS_IF_REQUIRED])dnl
+  m4_popdef([ES_DEFAULT_ACTIONS_IF_REQUIRED])dnl
 ])# ES_WITH_READLINE

--- a/m4/readline.m4
+++ b/m4/readline.m4
@@ -8,7 +8,7 @@ AC_DEFUN([_ES_CHECK_READLINE], [
   AS_VAR_COPY([saved_LIBS], [LIBS])
   AS_IF([test -n "$1"], [
     AS_VAR_SET([es_cv_readline_cflags], ["$1"])
-    AS_VAR_APPEND([CFLAGS], [" $es_cv_readline_cflags"])
+    AS_VAR_APPEND([CFLAGS], [" $1"])
   ])
   AC_LANG_CONFTEST([AC_LANG_PROGRAM([[
 #include <stdio.h>
@@ -99,10 +99,6 @@ AC_DEFUN([ES_WITH_READLINE], [
   AC_ARG_VAR([READLINE_CFLAGS], [C compiler flags for readline])
   AC_ARG_VAR([READLINE_LIBS], [linker flags for readline])
 
-  AS_IF([AS_VAR_TEST_SET([READLINE_CFLAGS])], [
-    AS_VAR_COPY([es_cv_readline_cflags], [READLINE_CFLAGS])
-  ])
-
   m4_pushdef([ES_REQUIRED_ERROR],
              [AC_MSG_FAILURE([readline support requested but unavailable])])dnl
   m4_pushdef([ES_DEFAULT_ACTIONS_IF_REQUIRED],
@@ -114,10 +110,10 @@ AC_DEFUN([ES_WITH_READLINE], [
 
   AS_CASE(["$with_readline"],
           [no],         [],
-          [auto|check], [ES_CHECK_READLINE([$es_cv_readline_cflags],
+          [auto|check], [ES_CHECK_READLINE([${READLINE_CFLAGS-}],
                                            [${READLINE_LIBS-}],
                                            [$1], [$2])],
-          [yes],        [ES_CHECK_READLINE([$es_cv_readline_cflags],
+          [yes],        [ES_CHECK_READLINE([${READLINE_CFLAGS-}],
                                            [${READLINE_LIBS-}],
                                            ES_DEFAULT_ACTIONS_IF_REQUIRED)],
           [AC_MSG_ERROR([--with-readline: valid values are "yes", "no", "check" -- got "$with_readline"])])

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -279,7 +279,7 @@ PRIM(setmaxevaldepth) {
 	RefReturn(lp);
 }
 
-#if READLINE
+#if HAVE_READLINE
 PRIM(resetterminal) {
 	resetterminal = TRUE;
 	return true;
@@ -315,7 +315,7 @@ extern Dict *initprims_etc(Dict *primdict) {
 	X(exitonfalse);
 	X(noreturn);
 	X(setmaxevaldepth);
-#if READLINE
+#if HAVE_READLINE
 	X(resetterminal);
 #endif
 	return primdict;

--- a/stdenv.h
+++ b/stdenv.h
@@ -108,7 +108,7 @@ extern void *qsort(
 );
 #endif /* !STDC_HEADERS */
 
-#if READLINE
+#if HAVE_READLINE
 # include <stdio.h>
 #endif
 

--- a/token.c
+++ b/token.c
@@ -68,7 +68,7 @@ const char dnw[] = {
 /* print_prompt2 -- called before all continuation lines */
 extern void print_prompt2(void) {
 	input->lineno++;
-#if READLINE
+#if HAVE_READLINE
 	prompt = prompt2;
 #else
 	if ((input->runflags & run_interactive) && prompt2 != NULL)

--- a/var.c
+++ b/var.c
@@ -379,7 +379,7 @@ extern void initvars(void) {
 	noexport = NULL;
 	env = mkvector(10);
 #if ABUSED_GETENV
-# if READLINE
+# if HAVE_READLINE
 	initgetenv();
 # endif
 #endif


### PR DESCRIPTION
This corrects a bug where `--with-readline=no/--without-readline` doesn't actually disable readline.
These days, shared libs are also used, so `-lreadline` alone is usually sufficient with the shared libreadline pulling in the necessary curses/terminfo/termcap lib (that's likely how this bug went unnoticed for so long).
In the event that static linking is required, however, linker tests are performed to determine which lib to link with, adding the first of `-lcurses`, `-ltinfo`, `-lterminfo`, or `-ltermcap` that links with a readline program and `-lreadline` successfully.

If `--with-readline=yes/--with-readline` is specified and the linker test fails in all of the above cases, which may also be due to incorrect CFLAGS resulting in failing to find `readline/readline.h` and `readline/history.h`, then configure fails with an error message.
The default is `--with-readline=check` so that configure can proceed without readline, and es can be built.

Support for a `READLINE_CFLAGS` variable is made available, so you can do something like

    ./configure READLINE_CFLAGS=-I/usr/local/include

without overriding your default `CFLAGS`.

And if you already know which linker flags to use, you can override the (potentially) time-consuming linker test using `READLINE_LIBS` without overriding your default `LDFLAGS`.
For example, either of the following works with the devel/readline port in FreeBSD 14, in case your compiler doesn't automatically search `/usr/local` for headers and libs:

    # shared libs
    ./configure \
        READLINE_CFLAGS=-I/usr/local/include \
        READLINE_LIBS='-L/usr/local/lib -lreadline'

    # static libs
    ./configure \
        READLINE_CFLAGS='--static -I/usr/local/include' \
        READLINE_LIBS='-L/usr/local/lib -lreadline -ltinfow'