### PR TITLE
Return true instead of the new PID from %background

### DIFF
--- a/initial.es
+++ b/initial.es
@@ -385,10 +385,10 @@ fn-%or = $&noreturn @ first rest {
 
 fn %background cmd {
 	let (pid = <={$&background $cmd}) {
+		apid = $pid
 		if {%is-interactive} {
 			echo >[1=2] $pid
 		}
-		apid = $pid
 	}
 }
 


### PR DESCRIPTION
I believe the fact that `%background` returns the PID of the process it creates is an oversight.

- It only happens as a side-effect of assigning `apid` to the new PID.
- The function has not changed since the "assignment returns the value" change went into effect.
- Other shells (including, most relevantly, _rc_) return true from `command &`
- It would be consistent with other cases where the "assignment returns the value" change had knock-on effects (see #70).
- It is entirely redundant to set `$apid`, print the new PID if interactive, _and_ return the PID
- In general there is a convention in _es_ commands that they either produce output by returning it, or by printing it/performing side effects, and there is a pattern of defining functions (e.g., `var`) which echo the value returned from "inner" functions (e.g., `%var`)