### PR TITLE
Update code related to compiler attributes

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -135,7 +135,7 @@ static Boolean deepequal(Tree *t1, Tree *t2) {
 	return FALSE;
 }
 
-static void treededup(void *arg, char unused *ignore, void *value) {
+static void treededup(void *arg, char UNUSED *ignore, void *value) {
 	Tree **new = arg;
 	Tree *old = value;
 	if (deepequal(*new, old))
@@ -242,7 +242,7 @@ static char *dumplist(List *list) {
 	return name;
 }
 
-static void dumpvar(void unused *ignore, char *key, void *value) {
+static void dumpvar(void UNUSED *ignore, char *key, void *value) {
 	Var *var = value;
 	dumpstring(key);
 	dumplist(var->defn);
@@ -252,17 +252,17 @@ static void dumpdef(char *name, Var *var) {
 	print("\t{ %s, (const List *) %s },\n", dumpstring(name), dumplist(var->defn));
 }
 
-static void dumpfunctions(void unused *ignore, char *key, void *value) {
+static void dumpfunctions(void UNUSED *ignore, char *key, void *value) {
 	if (hasprefix(key, "fn-"))
 		dumpdef(key, value);
 }
 
-static void dumpsettors(void unused *ignore, char *key, void *value) {
+static void dumpsettors(void UNUSED *ignore, char *key, void *value) {
 	if (hasprefix(key, "set-"))
 		dumpdef(key, value);
 }
 
-static void dumpvariables(void unused *ignore, char *key, void *value) {
+static void dumpvariables(void UNUSED *ignore, char *key, void *value) {
 	if (!hasprefix(key, "fn-") && !hasprefix(key, "set-"))
 		dumpdef(key, value);
 }

--- a/es.h
+++ b/es.h
@@ -247,7 +247,7 @@ extern void initconv(void);
 extern int print(const char *fmt VARARGS);
 extern int eprint(const char *fmt VARARGS);
 extern int fprint(int fd, const char *fmt VARARGS);
-extern noreturn(panic(const char *fmt VARARGS));
+extern Noreturn panic(const char *fmt VARARGS);
 
 
 /* str.c */
@@ -486,8 +486,8 @@ struct Handler {
 extern Handler *tophandler, *roothandler;
 extern List *exception;
 extern void pophandler(Handler *handler);
-extern noreturn(throw(List *exc));
-extern noreturn(fail(const char *from, const char *name VARARGS));
+extern Noreturn throw(List *exc);
+extern Noreturn fail(const char *from, const char *name VARARGS);
 extern void newchildcatcher(void);
 
 #if DEBUG_EXCEPTIONS

--- a/eval.c
+++ b/eval.c
@@ -4,7 +4,7 @@
 
 unsigned long evaldepth = 0, maxevaldepth = MAXmaxevaldepth;
 
-static noreturn failexec(char *file, List *args) {
+static Noreturn failexec(char *file, List *args) {
 	List *fn;
 	assert(gcisblocked());
 	fn = varlookup("fn-%exec-failure", NULL);

--- a/eval.c
+++ b/eval.c
@@ -81,7 +81,7 @@ static List *assign(Tree *varform, Tree *valueform0, Binding *binding0) {
 
 /* letbindings -- create a new Binding containing let-bound variables */
 static Binding *letbindings(Tree *defn0, Binding *outer0,
-			    Binding *context0, int unused evalflags) {
+			    Binding *context0, int UNUSED evalflags) {
 	Ref(Binding *, binding, outer0);
 	Ref(Binding *, context, context0);
 	Ref(Tree *, defn, defn0);

--- a/eval.c
+++ b/eval.c
@@ -426,8 +426,8 @@ restart:
 			if (t->kind == nPrim)
 				fail("es:eval", "invalid primitive name: %T", cp->tree);
 			RefEnd(t);
-			/* fallthrough */
 		    }
+		    FALLTHROUGH;
 		    default:
 			panic("eval: bad closure node kind %d",
 			      cp->tree->kind);

--- a/except.c
+++ b/except.c
@@ -17,7 +17,7 @@ extern void pophandler(Handler *handler) {
 }
 
 /* throw -- raise an exception */
-extern noreturn throw(List *e) {
+extern Noreturn throw(List *e) {
 	Handler *handler = tophandler;
 
 	assert(!gcisblocked());
@@ -48,7 +48,7 @@ extern noreturn throw(List *e) {
 }
 
 /* fail -- pass a user catchable error up the exception chain */
-extern noreturn fail VARARGS2(const char *, from, const char *, fmt) {
+extern Noreturn fail VARARGS2(const char *, from, const char *, fmt) {
 	char *s;
 	va_list args;
 

--- a/input.c
+++ b/input.c
@@ -655,7 +655,7 @@ static char *list_completion_function(const char *text, int state) {
 	return result;
 }
 
-char **builtin_completion(const char *text, int unused start, int unused end) {
+char **builtin_completion(const char *text, int UNUSED start, int UNUSED end) {
 	char **matches = NULL;
 
 	if (*text == '$') {

--- a/main.c
+++ b/main.c
@@ -68,7 +68,7 @@ static void runesrc(void) {
 }
 
 /* usage -- print usage message and die */
-static noreturn usage(void) {
+static Noreturn usage(void) {
 	eprint(
 		"usage: es [-c command] [-silevxnpo] [file [args ...]]\n"
 		"	-c cmd	execute argument\n"

--- a/match.c
+++ b/match.c
@@ -212,7 +212,7 @@ static List *extractsinglematch(const char *subject, const char *pattern,
 				}
 				i += j;
 			    }
-			    /* FALLTHROUGH */
+			    FALLTHROUGH;
 			    case '?':
 				result = mklist(mkstr(str("%c", *s)), result);
 				break;

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -246,6 +246,9 @@ PRIM(isinteractive) {
 	return isinteractive() ? true : false;
 }
 
+#ifdef noreturn
+#undef noreturn
+#endif
 PRIM(noreturn) {
 	if (list == NULL)
 		fail("$&noreturn", "usage: $&noreturn lambda args ...");

--- a/prim-io.c
+++ b/prim-io.c
@@ -41,7 +41,7 @@ static List *redir(List *(*rop)(int *fd, List *list), List *list, int evalflags)
 
 #define	REDIR(name)	static List *CONCAT(redir_,name)(int *srcfdp, List *list)
 
-static noreturn argcount(const char *s) {
+static Noreturn argcount(const char *s) {
 	fail(caller, "argument count: usage: %s", s);
 }
 

--- a/prim.h
+++ b/prim.h
@@ -1,7 +1,7 @@
 /* prim.h -- definitions for es primitives ($Revision: 1.1.1.1 $) */
 
 #define	PRIM(name)	static List *CONCAT(prim_,name)( \
-				List unused *list, Binding unused *binding, int unused evalflags \
+				List UNUSED *list, Binding UNUSED *binding, int UNUSED evalflags \
 			)
 #define	X(name)		(primdict = dictput( \
 				primdict, \

--- a/print.c
+++ b/print.c
@@ -281,7 +281,7 @@ extern int fmtprint VARARGS2(Format *, format, const char *, fmt) {
 	return n + format->flushed;
 }
 
-static void fprint_flush(Format *format, size_t unused more) {
+static void fprint_flush(Format *format, size_t UNUSED more) {
 	size_t n = format->buf - format->bufbegin;
 	char *buf = format->bufbegin;
 

--- a/print.c
+++ b/print.c
@@ -338,7 +338,7 @@ extern int eprint VARARGS1(const char *, fmt) {
 	return format.flushed;
 }
 
-extern noreturn panic VARARGS1(const char *, fmt) {
+extern Noreturn panic VARARGS1(const char *, fmt) {
 	Format format;
 	gcdisable();
 	VA_START(format.args, fmt);

--- a/signal.c
+++ b/signal.c
@@ -123,7 +123,7 @@ extern Sigeffect esignal(int sig, Sigeffect effect) {
 				eprint("$&setsignals: special handler not defined for %s\n", signame(sig));
 				return old;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		case sig_catch:
 		case sig_noop:
 			if (setsignal(sig, catcher) == SIG_ERR) {
@@ -301,7 +301,6 @@ extern void sigchk(void) {
 		while (gcisblocked())
 			gcenable();
 		throw(e);
-		NOTREACHED;
 	case sig_special:
 		assert(sig == SIGINT);
 		/* this is the newline you see when you hit ^C while typing a command */
@@ -311,8 +310,6 @@ extern void sigchk(void) {
 		while (gcisblocked())
 			gcenable();
 		throw(e);
-		NOTREACHED;
-		break;
 	case sig_noop:
 		break;
 	default:

--- a/stdenv.h
+++ b/stdenv.h
@@ -81,11 +81,11 @@ extern Dirent *readdir(DIR *);
 #endif
 #endif
 
-#ifndef unused
+#ifndef UNUSED
 #if __GNUC__
-#define unused __attribute__((__unused__))
+#define UNUSED __attribute__((__unused__))
 #else
-#define unused
+#define UNUSED
 #endif
 #endif
 

--- a/stdenv.h
+++ b/stdenv.h
@@ -73,12 +73,20 @@ extern Dirent *readdir(DIR *);
 #endif
 
 /* stdlib */
+#ifndef Noreturn
 #if __GNUC__
 #define Noreturn __attribute__((__noreturn__)) void
-#define unused __attribute__((__unused__))
 #else
 #define Noreturn void
+#endif
+#endif
+
+#ifndef unused
+#if __GNUC__
+#define unused __attribute__((__unused__))
+#else
 #define unused
+#endif
 #endif
 
 #if STDC_HEADERS

--- a/stdenv.h
+++ b/stdenv.h
@@ -74,22 +74,18 @@ extern Dirent *readdir(DIR *);
 
 /* stdlib */
 #if __GNUC__
-/* function declaration syntax */
-#define noreturn(F) volatile void F __attribute__((noreturn))
-/* function definition syntax */
-typedef volatile void noreturn;
-#define unused __attribute__((unused))
+#define Noreturn __attribute__((__noreturn__)) void
+#define unused __attribute__((__unused__))
 #else
-#define noreturn(F) void F
-typedef void noreturn;
+#define Noreturn void
 #define unused
 #endif
 
 #if STDC_HEADERS
 # include <stdlib.h>
 #else
-extern noreturn(exit(int));
-extern noreturn(abort(void));
+extern Noreturn exit(int);
+extern Noreturn abort(void);
 extern long strtol(const char *num, char **end, int base);
 extern void *qsort(
 	void *base, size_t nmemb, size_t size,

--- a/stdenv.h
+++ b/stdenv.h
@@ -6,17 +6,6 @@
 #endif
 
 /*
- * type qualifiers
- */
-
-#if !USE_VOLATILE
-# ifndef volatile
-#  define volatile
-# endif
-#endif
-
-
-/*
  * protect the rest of es source from the dance of the includes
  */
 

--- a/stdenv.h
+++ b/stdenv.h
@@ -89,6 +89,14 @@ extern Dirent *readdir(DIR *);
 #endif
 #endif
 
+#ifndef FALLTHROUGH
+#if __GNUC__
+#define FALLTHROUGH __attribute__((__fallthrough__))
+#else
+#define FALLTHROUGH (void)0
+#endif
+#endif
+
 #if STDC_HEADERS
 # include <stdlib.h>
 #else

--- a/token.c
+++ b/token.c
@@ -312,7 +312,7 @@ top:	while ((c = GETC()) == ' ' || c == '\t')
 		while ((c = GETC()) != '\n') /* skip comment until newline */
 			if (c == EOF)
 				return ENDFILE;
-		/* FALLTHROUGH */
+		FALLTHROUGH;
 	case '\n':
 		input->lineno++;
 		newline = TRUE;
@@ -321,7 +321,7 @@ top:	while ((c = GETC()) == ' ' || c == '\t')
 	case '(':
 		if (w == RW)	/* not keywords, so let & friends work */
 			c = SUB;
-		/* FALLTHROUGH */
+		FALLTHROUGH;
 	case ';':
 	case '^':
 	case ')':

--- a/var.c
+++ b/var.c
@@ -276,7 +276,7 @@ extern void varpop(Push *push) {
 		throw(except);
 }
 
-static void mkenv0(void unused *dummy, char *key, void *value) {
+static void mkenv0(void UNUSED *dummy, char *key, void *value) {
 	Var *var = value;
 	assert(gcisblocked());
 	if (
@@ -319,7 +319,7 @@ extern Vector *mkenv(void) {
 }
 
 /* addtolist -- dictforall procedure to create a list */
-extern void addtolist(void *arg, char *key, void unused *value) {
+extern void addtolist(void *arg, char *key, void UNUSED *value) {
 	List **listp = arg;
 	Term *term = mkstr(key);
 	*listp = mklist(term, *listp);
@@ -360,7 +360,7 @@ extern List *varswithprefix(char *prefix) {
 }
 
 /* hide -- worker function for dictforall to hide initial state */
-static void hide(void unused *dummy, char unused *key, void *value) {
+static void hide(void UNUSED *dummy, char UNUSED *key, void *value) {
 	((Var *) value)->flags |= var_isinternal;
 }
 


### PR DESCRIPTION
tl;dr

* `unused` macro renamed to `UNUSED` for consistency with macros like `STMT` and `NOP`
* `noreturn(F)` macro and `noreturn` typedef consolidated into a single macro `Noreturn`
* New `FALLTHROUGH` macro to indicate explicit fallthrough to GCC-compatible compilers that will otherwise warn about it when a flag like `-Wimplicit-fallthrough` is enabled
* `UNUSED`, `Noreturn`, and `FALLTHROUGH` are now conditionally defined.

- - -

### `UNUSED` name change

I renamed `unused` to `UNUSED` since other macros like `STMT` and `NOP` use all-caps names.
I also used the attribute name `__unused__` in place of `unused` so that any potential `unused` macro already defined wouldn't expand `__attribute__((unused))` to something like `__attribute__((__attribute__((__unused__))))`.
I realize the name change is a slightly intrusive and pedantic change, but considering 10 files were already affected by other changes and i was already modifying nearby code in stdenv.h, another 4 files didn't seem that bad.

### `Noreturn` fixes

Since `USE_VOLATILE` was removed back in 0.9 beta1's switch to Autoconf, `#define volatile` is always used in `stdenv.h`, resulting in `noreturn` being equivalent to unqualified `void`.
After deleting the `#define volatile` line and its surrounding code, i got a lot of warnings from both GCC 11 and GCC 14 about `volatile void` thanks to `-Wignored-qualifiers` (enabled by `-W`).
Unless _es_ intends to support ancient versions of GCC prior to 3.0, there's no need for `volatile void` when the `noreturn` compiler attribute is available.

The separate `noreturn(Func)` macro and `noreturn` type definition were suspicious to me, so i combined them into a single `Noreturn` macro that expands to `__attribute__((__noreturn__)) void`.
This particular spelling also reflects its usage as a type name, like `Boolean`.

### `FALLTHROUGH`

I added a `FALLTHROUGH` macro expanding to `__attribute__((__fallthrough__))` to be used in place of fallthrough comments.
The macro expands to `(void)0` if not using a GCC-compatible compiler, allowing `FALLTHROUGH;` to be used portably.
With Clang, `-Wimplicit-fallthrough` is a simple on/off flag and is not enabled by `-W`, but explicit inclusion of `-Wimplicit-fallthrough` in Clang is like `-Wimplicit-fallthrough=5` in GCC, requiring the use of attributes to silence the compiler warnings (fallthrough comments are ineffective).
This is what actually led me to create a `FALLTHROUGH` macro.

### Miscellaneous changes/improvements

Conditional definitions are used for all three macros.
Someone using a C23 compiler might want `-DNoreturn='[[__noreturn__]] void'` for example, or some system header (e.g. `<sys/cdefs.h>` or similar) might have already defined an `UNUSED` macro that does the right thing for the system compiler instead of expanding to nothing if it doesn't claim to be a GCC-compatible compiler.

Speaking of no-return functions, C11 also introduced a `<stdnoreturn.h>` header that exists solely to `#define noreturn _Noreturn`.
If some system header innocuously included `<stdnoreturn.h>`, `PRIM(noreturn)` and `__attribute__((noreturn))` would result in a `$&_Noreturn` primitive in all compilers and `__attribute__((_Noreturn)) void` being used when compiling with a GCC-compatible compiler.
This is why i changed the name to `Noreturn` and used the `__noreturn__` attribute instead.
To avoid the `$&_Noreturn` issue, i also conditionally `#undef noreturn` just before `PRIM(noreturn)` to keep the primitive named `$&noreturn`.

`-Wimplicit-fallthrough=3` (enabled by `-W` in GCC) made GCC 11.4 think code after invocation of a function marked `Noreturn` would still be executed.
`signal.c` was affected with two uses of `NOTREACHED` occurring after invocations of `throw()` that would cause the compiler to erroneously warn about implicit fallthrough between cases in a `switch`.
While a minor annoyance that appears to have been fixed in a later release of GCC (GCC 14.2 for example), i still opted to remove the useless uses of `NOTREACHED` that caused the spurious warnings since GCC 11 is only 3 years old.