### PR TITLE
Rename true/false -> ltrue/lfalse

### DIFF
--- a/es.h
+++ b/es.h
@@ -207,7 +207,7 @@ extern void varpop(Push *);
 
 /* status.c */
 
-extern List *true, *false;
+extern List *ltrue, *lfalse;
 extern Boolean istrue(List *status);
 extern int exitstatus(List *status);
 extern char *mkstatus(int status);

--- a/eval.c
+++ b/eval.c
@@ -163,7 +163,7 @@ static List *forloop(Tree *defn0, Tree *body0,
 		     Binding *binding, int evalflags) {
 	static List MULTIPLE = { NULL, NULL };
 
-	Ref(List *, result, true);
+	Ref(List *, result, ltrue);
 	Ref(Binding *, outer, binding);
 	Ref(Binding *, looping, NULL);
 	Ref(Tree *, body, body0);
@@ -245,7 +245,7 @@ static List *matchpattern(Tree *subjectform0, Tree *patternform0,
 	pattern = glom2(patternform, bp, &quote);
 	result = listmatch(subject, pattern, quote);
 	RefEnd4(quote, subject, patternform, bp);
-	return result ? true : false;
+	return result ? ltrue : lfalse;
 }
 
 /* extractpattern -- Like matchpattern, but returns matches */
@@ -272,7 +272,7 @@ extern List *walk(Tree *tree0, Binding *binding0, int flags) {
 
 top:
 	if (tree == NULL)
-		return true;
+		return ltrue;
 
 	switch (tree->kind) {
 
@@ -371,7 +371,7 @@ restart:
 	if (list == NULL) {
 		RefPop3(funcname, binding, list);
 		--evaldepth;
-		return true;
+		return ltrue;
 	}
 	assert(list->term != NULL);
 

--- a/prim-ctl.c
+++ b/prim-ctl.c
@@ -4,7 +4,7 @@
 #include "prim.h"
 
 PRIM(seq) {
-	Ref(List *, result, true);
+	Ref(List *, result, ltrue);
 	Ref(List *, lp, list);
 	for (; lp != NULL; lp = lp->next)
 		result = eval1(lp->term, evalflags &~ (lp->next == NULL ? 0 : eval_inchild));
@@ -28,7 +28,7 @@ PRIM(if) {
 		}
 	}
 	RefEnd(lp);
-	return true;
+	return ltrue;
 }
 
 PRIM(forever) {

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -19,7 +19,7 @@ PRIM(echo) {
 			list = list->next;
 	}
 	print("%L%s", list, " ", eol);
-	return true;
+	return ltrue;
 }
 
 PRIM(count) {
@@ -184,7 +184,7 @@ PRIM(exitonfalse) {
 }
 
 PRIM(batchloop) {
-	Ref(List *, result, true);
+	Ref(List *, result, ltrue);
 	Ref(List *, dispatch, NULL);
 
 	SIGCHK();
@@ -212,8 +212,8 @@ PRIM(batchloop) {
 		if (!termeq(e->term, "eof"))
 			throw(e);
 		RefEnd(dispatch);
-		if (result == true)
-			result = true;
+		if (result == ltrue)
+			result = ltrue;
 		RefReturn(result);
 
 	EndExceptionHandler
@@ -221,7 +221,7 @@ PRIM(batchloop) {
 
 PRIM(collect) {
 	gc();
-	return true;
+	return ltrue;
 }
 
 PRIM(home) {
@@ -243,7 +243,7 @@ PRIM(internals) {
 }
 
 PRIM(isinteractive) {
-	return isinteractive() ? true : false;
+	return isinteractive() ? ltrue : lfalse;
 }
 
 PRIM(noreturn) {
@@ -282,7 +282,7 @@ PRIM(setmaxevaldepth) {
 #if READLINE
 PRIM(resetterminal) {
 	resetterminal = TRUE;
-	return true;
+	return ltrue;
 }
 #endif
 

--- a/prim-sys.c
+++ b/prim-sys.c
@@ -39,7 +39,7 @@ PRIM(newpgrp) {
 		esignal(SIGTTOU, sigttou);
 	}
 #endif
-	return true;
+	return ltrue;
 }
 
 PRIM(background) {
@@ -81,7 +81,7 @@ PRIM(umask) {
 		int mask = umask(0);
 		umask(mask);
 		print("%04o\n", mask);
-		return true;
+		return ltrue;
 	}
 	if (list->next == NULL) {
 		int mask;
@@ -91,7 +91,7 @@ PRIM(umask) {
 		if ((t != NULL && *t != '\0') || ((unsigned) mask) > 07777)
 			fail("$&umask", "bad umask: %s", s);
 		umask(mask);
-		return true;
+		return ltrue;
 	}
 	fail("$&umask", "usage: umask [mask]");
 	NOTREACHED;
@@ -104,7 +104,7 @@ PRIM(cd) {
 	dir = getstr(list->term);
 	if (chdir(dir) == -1)
 		fail("$&cd", "chdir %s: %s", dir, esstrerror(errno));
-	return true;
+	return ltrue;
 }
 
 PRIM(setsignals) {
@@ -290,7 +290,7 @@ PRIM(limit) {
 		}
 	}
 	RefEnd(lp);
-	return true;
+	return ltrue;
 }
 #endif	/* BSD_LIMITS */
 

--- a/status.c
+++ b/status.c
@@ -10,8 +10,8 @@ static const List
 	truelist	= { (Term *) &trueterm, NULL },
 	falselist	= { (Term *) &falseterm, NULL };
 List
-	*true		= (List *) &truelist,
-	*false		= (List *) &falselist;
+	*ltrue		= (List *) &truelist,
+	*lfalse		= (List *) &falselist;
 
 /* istrue -- is this status list true? */
 extern Boolean istrue(List *status) {


### PR DESCRIPTION
`true` and `false` have been made into keywords in C23, so this PR renames those `List *` variables to `ltrue` and `lfalse` to allow compilation with C23 compilers.
_XS_ previously did the same since they were keywords in C++ already, so this is mostly a C23 compatibility fix to allow _es_ to still compile whenever compiler vendors make C23 the default standard.
Judging by the gap of 3-4 years between C11/C17 being published and `-std=gnu11/-std=gnu17` becoming the default in GCC and Clang, i expect those two compiler suites will make `-std=gnu23` the default in 2028 at the latest.