### PR TITLE
Delay settor invocation at startup

### DIFF
--- a/var.c
+++ b/var.c
@@ -479,6 +479,7 @@ extern void initenv(char **envp, Boolean protected) {
 	}
 	RefEnd(name);
 
+	sortvector(imported);
 	for (i = 0; i < imported->count; i++)
 		callsettor(imported->vector[i], varlookup(imported->vector[i], NULL));
 

--- a/var.c
+++ b/var.c
@@ -481,7 +481,7 @@ extern void initenv(char **envp, Boolean protected) {
 
 	sortvector(imported);
 	for (i = 0; i < imported->count; i++)
-		callsettor(imported->vector[i], varlookup(imported->vector[i], NULL));
+		vardef(imported->vector[i], NULL, varlookup(imported->vector[i], NULL));
 
 	RefEnd(imported);
 	envmin = env->count;


### PR DESCRIPTION
This is a relatively simple change that addresses #127.  It implements the suggestion in the mailing list here: http://wryun.github.io/es-shell/mail-archive/msg00837.html

As discussed in #127, settor functions on startup still have some pitfalls with this change.  Unfortunately, there's probably no perfect way to invoke settors on startup; the zero-flake fix would be to avoid running settors on startup at _all_, and instead establish some kind of `%init` hook function on startup that can implement the same behavior in a more deterministic way.  But that's a backwards-incompatible change that requires some real design consideration.  This change makes things at least somewhat better without any breaking changes or novel design work required.  (Concretely, it fixes the ability to define a `cdpath`/`CDPATH` pair the same way as `path`/`PATH` and have it work in subshells, which is part of what I am adding in #123.)

We also sort the `imported` vector before scanning it for settor functions, which should also help de-flake settor function semantics despite any environment reordering.  At first I thought this would be unnecessary, but looking closer it seems like a lot of shells like to cook up a different sort order for their exported environment.

Here we also default the capacity of the various vectors doing environment import to 40 elements, rather than 10.