### PR TITLE
Add canonical extensions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -33,9 +33,10 @@ execute configure with a path to the source.  For example:
    Also obeying the GNU configure convention, configure will take
 arguments specifying a variety of directories.  Currently the only
 relevant ones are the prefix directory (/usr/local by default); bindir,
-the directory in which `es' will reside ($prefix/bin by default); and
+the directory in which `es' will reside ($prefix/bin by default);
 mandir, the directory that will contain the manpage ($prefix/man by
-default).  These are given to configure by:
+default); and datadir, the directory that will contain the es script
+library ($prefix/share by default).  These are given to configure by:
 
    % ./configure --prefix=directory
    % ./configure --bindir=directory --mandir=directory

--- a/Makefile.in
+++ b/Makefile.in
@@ -26,8 +26,9 @@
 # to get definitions of all signals from <sys/signal.h>.
 # _POSIX_SOURCE, _XOPEN_SOURCE are the obvious ones.
 
-datarootdir = @datarootdir@
 prefix  = @prefix@
+datarootdir = @datarootdir@
+datadir	= @datadir@
 exec_prefix	= @exec_prefix@
 mandir	= @mandir@
 bindir	= @bindir@
@@ -38,6 +39,8 @@ testdir	= @srcdir@/test
 SHELL	= /bin/sh
 CC	= @CC@
 INSTALL	= @INSTALL@
+INSTALL_PROGRAM	= ${INSTALL}
+INSTALL_DATA	= ${INSTALL} -m 644
 MKDIR_P = @MKDIR_P@
 
 
@@ -85,9 +88,11 @@ MANIFEST:
 
 install : es
 	$(MKDIR_P) $(DESTDIR)$(bindir)
-	$(INSTALL) -s $(srcdir)/es $(DESTDIR)$(bindir)
+	$(INSTALL_PROGRAM) -s $(srcdir)/es $(DESTDIR)$(bindir)
 	$(MKDIR_P) $(DESTDIR)$(mandir)/man1
-	$(INSTALL) $(srcdir)/doc/es.1 $(DESTDIR)$(mandir)/man1
+	$(INSTALL_DATA) $(srcdir)/doc/es.1 $(DESTDIR)$(mandir)/man1
+	$(MKDIR_P) $(DESTDIR)$(datadir)/es
+	$(INSTALL_DATA) $(srcdir)/share/* $(DESTDIR)$(datadir)/es
 
 test	: es $(testdir)/test.es
 	$(srcdir)/es -s < $(testdir)/test.es $(testdir)/tests/*

--- a/doc/es.1
+++ b/doc/es.1
@@ -1790,7 +1790,6 @@ when invoked in this way, the shell prints the internal form of its commands
 rather than executing them.
 .ta 2.3i
 .SS "Control Flow"
-\&
 .Ds
 .ft \*(Cf
 ! \fIcmd\fP	%not {\fIcmd\fP}
@@ -1802,7 +1801,6 @@ fn \fIname\fP \fIargs\fP { \fIcmd\fP }	fn-^\fIname\fP = @ \fIargs\fP {\fIcmd\fP}
 .ft R
 .De
 .SS "Input/Output Commands"
-\&
 .Ds
 .ft \*(Cf
 \fIcmd\fP < \fIfile\fP	%open 0 \fIfile\fP {\fIcmd\fP}
@@ -1824,7 +1822,6 @@ fn \fIname\fP \fIargs\fP { \fIcmd\fP }	fn-^\fIname\fP = @ \fIargs\fP {\fIcmd\fP}
 .ft R
 .De
 .SS "Expressions"
-\&
 .Ds
 .ft \*(Cf
 $#\fIvar\fP	<={%count $\fIvar\fP}
@@ -2848,6 +2845,97 @@ Don't trap
 or
 .Cr SIGTERM .
 This is used for debugging.
+.SH EXTENSION SCRIPTS
+.I Es
+is distributed with a directory of extension scripts, which implement a number
+of features commonly desired by users but not built into the shell.
+These scripts are typically installed into the
+.Cr $share/es
+directory, where
+.Cr $share
+is a directory like
+.Cr /usr/share " or " /usr/local/share
+which corresponds with the
+.Cr bin
+directory into which the
+.I es
+binary is installed.
+.PP
+These scripts generally work by spoofing hook functions within
+.I es
+and can be read as a demonstration of how these spoofs work.
+They are intended to be invoked as
+.Ds
+.Ci ". " /path/to/script.es
+.De
+.PP
+in
+.Cr $home/.esrc ,
+though they can also be invoked at the interactive command line or even in
+scripts (though they may not be particularly useful when invoked in those
+cases).
+.PP
+Features currently distributed via extension scripts include:
+.TP
+.Cr autoload.es
+adds behavior to
+.I es
+to search a directory of scripts for a file which defines a function which
+would otherwise be undefined.
+This corresponds somewhat with the function-autoloading feature of shells
+like
+.IR ksh (1)
+and 
+.IR zsh (1).
+.TP
+.Cr cdpath.es
+implements
+.IR rc (1)-style
+.Cr $cdpath
+searching to the
+.Cr cd
+builtin.
+.TP
+.Cr interactive-init.es
+adds a hook for a function
+.Cr %interactive-init
+to be called at the beginning of
+.Cr %interactive-loop .
+By invoking
+.Ci ". " /path/to/ interactive-init.es
+and defining
+.Ds
+.Ci "fn %interactive-loop {"
+.Ci "  . " startup-script.es
+.Cr "}"
+.De
+in their
+.Cr .esrc ,
+users can have a
+.Cr .bashrc -like
+interactive startup script.
+.TP
+.Cr path-cache.es
+adds behavior to
+.Cr %pathsearch
+to ``cache'' the location of external commands by automatically defining
+.Ds
+.Ci fn- command " = " /path/to/command
+.De
+when paths are found.
+This is helpful to performance when path searching is slow, and corresponds
+with the ``hashing'' behavior in some other shells.
+.TP
+.Cr status.es
+This adds a variable
+.Cr $status
+which contains the return value of commands run at the interactive command
+line, like
+.IR rc (1)
+has.
+.PP
+Users interested in these features should peruse the scripts themselves for
+more precise information on their use.
 .SH FILES
 .Cr $home/.esrc ,
 .Cr /dev/null

--- a/doc/es.1
+++ b/doc/es.1
@@ -2880,8 +2880,8 @@ Features currently distributed via extension scripts include:
 .Cr autoload.es
 adds behavior to
 .I es
-to search a directory of scripts for a file which defines a function which
-would otherwise be undefined.
+to search an autoload directory containing function definitions which it
+will read and define on the fly.
 This corresponds somewhat with the function-autoloading feature of shells
 like
 .IR ksh (1)
@@ -2905,7 +2905,7 @@ By invoking
 .Ci ". " /path/to/ interactive-init.es
 and defining
 .Ds
-.Ci "fn %interactive-loop {"
+.Ci "fn %interactive-init {"
 .Ci "  . " startup-script.es
 .Cr "}"
 .De

--- a/doc/es.1
+++ b/doc/es.1
@@ -1895,7 +1895,6 @@ Is the file writable?
 .TP
 .Cr \-x
 Is the file executable?
-.sp .7v
 .TP
 .Cr \-f
 Is the file a plain file?
@@ -2165,7 +2164,6 @@ functions
 .TP
 .Cr \-s
 settor functions
-.sp .7v
 .TP
 .Cr \-e
 exported values
@@ -2175,7 +2173,6 @@ private (not exported) values
 .TP
 .Cr \-i
 internal (predefined and builtin) values
-.sp .7v
 .TP
 .Cr \-a
 all of the above
@@ -2845,51 +2842,46 @@ Don't trap
 or
 .Cr SIGTERM .
 This is used for debugging.
-.SH EXTENSION SCRIPTS
+.SH CANONICAL EXTENSIONS
 .I Es
-is distributed with a directory of extension scripts, which implement a number
-of features commonly desired by users but not built into the shell.
-These scripts are typically installed into the
-.Cr $share/es
-directory, where
-.Cr $share
-is a directory like
-.Cr /usr/share " or " /usr/local/share
-which corresponds with the
-.Cr bin
-directory into which the
+is distributed with a directory of ``canonical extension'' scripts, which
+implement a number of features commonly desired by users but not built into
+the shell itself.
+They are typically installed into either
+.Cr /usr/share/es
+or
+.Cr /usr/local/share/es ,
+corresponding with wherever the
 .I es
-binary is installed.
+binary itself is installed.
 .PP
-These scripts generally work by spoofing hook functions within
+In general, these scripts work by spoofing hook functions within
 .I es
-and can be read as a demonstration of how these spoofs work.
+and can be read as a demonstration of how these spoofs and hooks work.
 They are intended to be invoked as
 .Ds
 .Ci ". " /path/to/script.es
 .De
 .PP
 in
-.Cr $home/.esrc ,
-though they can also be invoked at the interactive command line or even in
-scripts (though they may not be particularly useful when invoked in those
-cases).
+.Cr $home/.esrc .
+They can also be invoked at the interactive command line or even within other
+scripts, though they may not be particularly useful when invoked in those
+contexts.
 .PP
-Features currently distributed via extension scripts include:
+Features currently distributed as canonical extensions include:
 .TP
 .Cr autoload.es
-adds behavior to
+Adds behavior to
 .I es
-to search an autoload directory containing function definitions which it
-will read and define on the fly.
-This corresponds somewhat with the function-autoloading feature of shells
-like
-.IR ksh (1)
-and 
-.IR zsh (1).
+to search the directory given by
+.Cr $es-autoload
+(by default
+.Cr $home/bin/es )
+containing function definitions which are then defined on-demand.
 .TP
 .Cr cdpath.es
-implements
+Implements
 .IR rc (1)-style
 .Cr $cdpath
 searching to the
@@ -2897,7 +2889,7 @@ searching to the
 builtin.
 .TP
 .Cr interactive-init.es
-adds a hook for a function
+Adds a hook for a function
 .Cr %interactive-init
 to be called at the beginning of
 .Cr %interactive-loop .
@@ -2909,33 +2901,33 @@ and defining
 .Ci "  . " startup-script.es
 .Cr "}"
 .De
-in their
+.sp .7v
+in
 .Cr .esrc ,
-users can have a
-.Cr .bashrc -like
-interactive startup script.
+this function also enables interactive-shell startup scripts.
 .TP
 .Cr path-cache.es
-adds behavior to
+Adds behavior to
 .Cr %pathsearch
 to ``cache'' the location of external commands by automatically defining
 .Ds
 .Ci fn- command " = " /path/to/command
 .De
-when paths are found.
-This is helpful to performance when path searching is slow, and corresponds
-with the ``hashing'' behavior in some other shells.
+.sp .7v
+when paths to external commands are found.
+This can be helpful to performance when path searching is slow, and
+corresponds with the ``hashing'' behavior found in some other shells.
 .TP
 .Cr status.es
-This adds a variable
+Adds a variable
 .Cr $status
 which contains the return value of commands run at the interactive command
-line, like
-.IR rc (1)
-has.
+line, somewhat like that of
+.IR rc (1).
 .PP
-Users interested in these features should peruse the scripts themselves for
-more precise information on their use.
+These are only short descriptions; users interested in these features
+should peruse the scripts themselves for more precise information on
+their use.
 .SH FILES
 .Cr $home/.esrc ,
 .Cr /dev/null

--- a/doc/es.1
+++ b/doc/es.1
@@ -2877,7 +2877,11 @@ Adds behavior to
 to search the directory given by
 .Cr $es-autoload
 (by default
-.Cr $home/bin/es )
+.Cr $XDG_DATA_HOME/es/autoload
+or, if
+.Cr $XDG_DATA_HOME
+is not set,
+.Cr ~/.local/share/es/autoload ,)
 containing function definitions which are then defined on-demand.
 .TP
 .Cr cdpath.es
@@ -2930,6 +2934,7 @@ should peruse the scripts themselves for more precise information on
 their use.
 .SH FILES
 .Cr $home/.esrc ,
+.Cr /usr/share/es ,
 .Cr /dev/null
 .SH BUGS
 Lexical scope which is shared by two variables (or closures) in a parent shell

--- a/share/autoload.es
+++ b/share/autoload.es
@@ -20,8 +20,8 @@ let (search = $fn-%pathsearch)
 fn %pathsearch prog {
 	let (autoload = $XDG_DATA_HOME/es/autoload) {
 		if {!~ $#es-autoload 0} {
-			autoload = $es-autoload
-		} {!~ $autoload 1} {
+			autoload = $es-autoload(1)
+		} {!~ $#autoload 1} {
 			autoload = ~/.local/share/es/autoload
 		}
 		if {access -f -r $autoload/$prog} {

--- a/share/autoload.es
+++ b/share/autoload.es
@@ -1,14 +1,15 @@
 # autoload.es -- Auto-load shell functions on demand.
 #
-# The function, say, foo, should be in the file foo and should contain the
-# definition of the function, as in
+# An autoloadable function, say, foo, should be in the file foo and should
+# contain the definition of the function, as in
 #
+#	; cat foo
 #	fn foo args {
 #		body
 #	}
 #
 # By default, the autoload directory is ~/bin/es.  The $es-autoload variable can
-# be set in order to use a different directory.
+# be set to a different directory if that is desired.
 #
 # This is a light adaptation of the original version written by Paul Haahr.
 # See esrc.haahr in the examples directory for more of his setup.

--- a/share/autoload.es
+++ b/share/autoload.es
@@ -8,17 +8,21 @@
 #		body
 #	}
 #
-# By default, the autoload directory is ~/bin/es.  The $es-autoload variable can
-# be set to a different directory if that is desired.
+# By default, the autoload directory is $XDG_DATA_HOME/es/autoload (if
+# $XDG_DATA_HOME is unset, that defaults to ~/.local/share/es/autoload).
+# The autoload directory can be changed by setting $es-autoload to the desired
+# location.
 #
 # This is a light adaptation of the original version written by Paul Haahr.
 # See esrc.haahr in the examples directory for more of his setup.
 
 let (search = $fn-%pathsearch)
 fn %pathsearch prog {
-	let (autoload = ~/bin/es) {
+	let (autoload = $XDG_DATA_HOME/es/autoload) {
 		if {!~ $#es-autoload 0} {
 			autoload = $es-autoload
+		} {!~ $autoload 1} {
+			autoload = ~/.local/share/es/autoload
 		}
 		if {access -f -r $autoload/$prog} {
 			. $autoload/$prog

--- a/share/autoload.es
+++ b/share/autoload.es
@@ -1,0 +1,30 @@
+# autoload.es -- Auto-load shell functions on demand.
+#
+# The function, say, foo, should be in the file foo and should contain the
+# definition of the function, as in
+#
+#	fn foo args {
+#		body
+#	}
+#
+# By default, the autoload directory is ~/bin/es.  The $es-autoload variable can
+# be set in order to use a different directory.
+#
+# This is a light adaptation of the original version written by Paul Haahr.
+# See esrc.haahr in the examples directory for more of his setup.
+
+let (search = $fn-%pathsearch)
+fn %pathsearch prog {
+	let (autoload = ~/bin/es) {
+		if {!~ $#es-autoload 0} {
+			autoload = $es-autoload
+		}
+		if {access -f -r $autoload/$prog} {
+			. $autoload/$prog
+			if {!~ $#(fn-$prog) 0} {
+				return $(fn-$prog)
+			}
+		}
+	}
+	$search $prog
+}

--- a/share/cdpath.es
+++ b/share/cdpath.es
@@ -12,18 +12,14 @@
 
 let (cd = $fn-cd)
 fn cd dir {
-	if {~ $#dir 1} {
-		if {!~ $dir /* ./* ../*} {
-			let (old = $dir) {
-				dir = <={%cdpathsearch $dir}
-				if {!~ $dir $old} {
-					echo >[1=2] $dir
-				}
-			}
+	if {!~ $#dir 1 || ~ $dir (/* ./* ../*)} {
+		return <={$cd $dir}
+	}
+	let (abs = <={%cdpathsearch $dir}) {
+		if {!~ $abs ($dir ./$dir)} {
+			echo >[1=2] $abs
 		}
-		$cd $dir
-	} {
-		$cd $dir
+		$cd $abs
 	}
 }
 
@@ -35,18 +31,17 @@ fn %cdpathsearch name { access -n $name -1e -d $cdpath }
 
 # cdpath and CDPATH contain the list of directories to search for cd.  They
 # follow the convention that the uppercase CDPATH contains a single colon-
-# separated word as is common in UNIX, while the lowercase cdpath contains an
-# es list.  CDPATH is exported while cdpath is not.
+# separated word which is understandable to other CDPATH-using shells, while
+# the lowercase cdpath contains an es list.  For interoperability with other
+# utilities, CDPATH is exported while cdpath is not.
 
 set-cdpath = @ {local (set-CDPATH = ) CDPATH = <={%flatten : $*}; result $*}
 set-CDPATH = @ {local (set-cdpath = ) cdpath = <={%fsplit  : $*}; result $*}
 
 noexport = $noexport cdpath
 
-# The default value of cdpath is ''.  This corresponds with "the current
-# directory".  If cdpath is the empty list, then path searching behavior will
-# not work, and it will only be possible to cd to paths starting with one of
-# (/ ./ ../).  This is more consistent behavior, but may be more surprising to
-# an unsuspecting user.
+# The default value of cdpath is '.': the current directory.  If cdpath is the
+# empty list, then path searching behavior will not work, and it will only be
+# possible to cd to paths starting with one of (/ ./ ../).
 
-cdpath = ''
+cdpath = .

--- a/share/cdpath.es
+++ b/share/cdpath.es
@@ -38,9 +38,6 @@ fn %cdpathsearch name { access -n $name -1e -d $cdpath }
 # separated word as is common in UNIX, while the lowercase cdpath contains an
 # es list.  CDPATH is exported while cdpath is not.
 
-# TODO: Test: Does this "variable pairing" setup actually work when noexport is
-# itself noexport?
-
 set-cdpath = @ {local (set-CDPATH = ) CDPATH = <={%flatten : $*}; result $*}
 set-CDPATH = @ {local (set-cdpath = ) cdpath = <={%fsplit  : $*}; result $*}
 

--- a/share/cdpath.es
+++ b/share/cdpath.es
@@ -1,0 +1,55 @@
+# cdpath.es -- Add rc-like $cdpath behavior to es.
+#
+# `cd'ing to an absolute directory (one which starts with a /, ./, or ../) is
+# unchanged.  For any other directory, cd performs a path-search for the
+# directory in the list given by the $cdpath variable.
+#
+# If multiple arguments are given, then path searching is not performed, as we
+# don't know a priori which of the arguments are meant to be a searchable
+# directory.  Perhaps a future improvement -- decomposing the cdpath behavior
+# to allow more-extended definitions of cd to integrate $cdpath a bit more
+# easily.
+
+let (cd = $fn-cd)
+fn cd dir {
+	if {~ $#dir 1} {
+		if {!~ $dir /* ./* ../*} {
+			let (old = $dir) {
+				dir = <={%cdpathsearch $dir}
+				if {!~ $dir $old} {
+					echo >[1=2] $dir
+				}
+			}
+		}
+		$cd $dir
+	} {
+		$cd $dir
+	}
+}
+
+# %cdpathsearch performs the cdpath-searching behavior for cd.  It is nearly
+# identical to the default %pathsearch, except it searches for directories
+# rather than executable files.
+
+fn %cdpathsearch name { access -n $name -1e -d $cdpath }
+
+# cdpath and CDPATH contain the list of directories to search for cd.  They
+# follow the convention that the uppercase CDPATH contains a single colon-
+# separated word as is common in UNIX, while the lowercase cdpath contains an
+# es list.  CDPATH is exported while cdpath is not.
+
+# TODO: Test: Does this "variable pairing" setup actually work when noexport is
+# itself noexport?
+
+set-cdpath = @ {local (set-CDPATH = ) CDPATH = <={%flatten : $*}; result $*}
+set-CDPATH = @ {local (set-cdpath = ) cdpath = <={%fsplit  : $*}; result $*}
+
+noexport = $noexport cdpath
+
+# The default value of cdpath is ''.  This corresponds with "the current
+# directory".  If cdpath is the empty list, then path searching behavior will
+# not work, and it will only be possible to cd to paths starting with one of
+# (/ ./ ../).  This is more consistent behavior, but may be more surprising to
+# an unsuspecting user.
+
+cdpath = ''

--- a/share/cdpath.es
+++ b/share/cdpath.es
@@ -35,8 +35,16 @@ fn %cdpathsearch name { access -n $name -1e -d $cdpath }
 # the lowercase cdpath contains an es list.  For interoperability with other
 # utilities, CDPATH is exported while cdpath is not.
 
+# Somewhat awkwardly, we have to "re-noexport" cdpath in each shell, because
+# noexport is itself not exported, so es "forgets" about noexport state.  This
+# is probably correct, but it's not convenient in this case.
+
 set-cdpath = @ {local (set-CDPATH = ) CDPATH = <={%flatten : $*}; result $*}
-set-CDPATH = @ {local (set-cdpath = ) cdpath = <={%fsplit  : $*}; result $*}
+set-CDPATH = @ {
+	local (set-cdpath = ) cdpath = <={%fsplit  : $*}
+	if {!~ $noexport cdpath} {noexport = $noexport cdpath}
+	result $*
+}
 
 noexport = $noexport cdpath
 

--- a/share/cdpath.es
+++ b/share/cdpath.es
@@ -35,13 +35,14 @@ fn %cdpathsearch name { access -n $name -1e -d $cdpath }
 # the lowercase cdpath contains an es list.  For interoperability with other
 # utilities, CDPATH is exported while cdpath is not.
 
-# Somewhat awkwardly, we have to "re-noexport" cdpath in each shell, because
-# noexport is itself not exported, so es "forgets" about noexport state.  This
-# is probably correct, but it's not convenient in this case.
+# Somewhat awkwardly, we have to "re-noexport" cdpath in each shell which
+# inherits CDPATH, because noexport is itself not exported, so es "forgets"
+# about noexport state.  This is probably the correct behavior in general, but
+# it's not very convenient in this case.
 
 set-cdpath = @ {local (set-CDPATH = ) CDPATH = <={%flatten : $*}; result $*}
 set-CDPATH = @ {
-	local (set-cdpath = ) cdpath = <={%fsplit  : $*}
+	local (set-cdpath = ) cdpath = <={%fsplit : $*}
 	if {!~ $noexport cdpath} {noexport = $noexport cdpath}
 	result $*
 }

--- a/share/interactive-init.es
+++ b/share/interactive-init.es
@@ -1,0 +1,16 @@
+# interactive-init.es -- Add a hook function %interactive-init.
+#
+# If defined, the function %interactive-init is called with no arguments before
+# the interactive loop starts.
+
+let (loop = $fn-%interactive-loop)
+fn %interactive-loop {
+	if {!~ $#fn-%interactive-init 0} {
+		catch @ e {
+			echo >[1=2] uncaught exception from %interactive-init: $e
+		} {
+			%interactive-init
+		}
+	}
+	$loop $*
+}

--- a/share/interactive-init.es
+++ b/share/interactive-init.es
@@ -1,15 +1,20 @@
 # interactive-init.es -- Add a hook function %interactive-init.
 #
 # If defined, the function %interactive-init is called with no arguments before
-# the interactive loop starts.  It is called within a very simple exception
-# handler so that any exceptions coming from %interactive-init don't disrupt the
-# user's ability to use the shell.
+# the interactive loop starts.  It is called with a simple exception handler so
+# that any exceptions coming from %interactive-init don't break the shell.
 
 let (loop = $fn-%interactive-loop)
 fn %interactive-loop {
 	if {!~ $#fn-%interactive-init 0} {
-		catch @ e {
-			echo >[1=2] uncaught exception from %interactive-init: $e
+		catch @ e type msg {
+			if {~ $e exit} {
+				exit $type $msg
+			} {~ $e error} {
+				echo >[1=2] $msg
+			} {!~ $e signal || !~ $type sigint} {
+				echo >[1=2] uncaught exception: $e $type $msg
+			}
 		} {
 			%interactive-init
 		}

--- a/share/interactive-init.es
+++ b/share/interactive-init.es
@@ -1,7 +1,9 @@
 # interactive-init.es -- Add a hook function %interactive-init.
 #
 # If defined, the function %interactive-init is called with no arguments before
-# the interactive loop starts.
+# the interactive loop starts.  It is called within a very simple exception
+# handler so that any exceptions coming from %interactive-init don't disrupt the
+# user's ability to use the shell.
 
 let (loop = $fn-%interactive-loop)
 fn %interactive-loop {

--- a/share/path-cache.es
+++ b/share/path-cache.es
@@ -72,4 +72,4 @@ set-cache-path = @ {
 }
 
 let (sp = $set-path) set-path = @ {cache-path = $*; $sp $*}
-let (sp = $set-PATH) set-PATH = @ {cache-path = $*; $sp $*}
+let (sp = $set-PATH) set-PATH = @ {cache-path = <={%fsplit : $*}; $sp $*}

--- a/share/path-cache.es
+++ b/share/path-cache.es
@@ -50,12 +50,26 @@ fn recache progs {
 	}
 }
 
-# path-cache and the fn-$progs defined by %pathsearch, are exported to the
+# path-cache and the fn-$progs defined by %pathsearch are exported to the
 # environment, under the assumption that subshells will also benefit from the
-# already built cache.
-
-# TODO: recache should be called if PATH is changed.  Exported path-cache
-# complicates this a bit (consider es calling a binary which changes PATH and
-# then calls es again).
+# already-built cache.
 
 path-cache = ()
+
+# cache-path, along with this set of settor functions, ensure that when the path
+# is changed, recache is called.
+
+cache-path = $path
+
+set-cache-path = @ {
+	for (o = $cache-path; n = $*) {
+		if {!~ $o $n} {
+			recache
+			break
+		}
+	}
+	result $*
+}
+
+let (sp = $set-path) set-path = @ {cache-path = $*; $sp $*}
+let (sp = $set-PATH) set-PATH = @ {cache-path = $*; $sp $*}

--- a/share/path-cache.es
+++ b/share/path-cache.es
@@ -50,6 +50,26 @@ fn recache progs {
 	}
 }
 
+# precache also takes a list of binaries.  For each one, if the binary is
+# valid, it caches the binary in the path cache without running it.  This can
+# be useful in ~/.esrc for pre-caching binaries which are known ahead of time to
+# be frequently used.
+
+fn precache progs {
+	let (result = ())
+	for (p = $progs) {
+		catch @ e type msg {
+			if {~ $e error} {
+				echo >[1=2] $p: $msg
+			} {
+				throw $e $type $msg
+			}
+		} {
+			result = $result <={%pathsearch $p}
+		}
+	}
+}
+
 # path-cache and the fn-$progs defined by %pathsearch are exported to the
 # environment, under the assumption that subshells will also benefit from the
 # already-built cache.

--- a/share/path-cache.es
+++ b/share/path-cache.es
@@ -1,0 +1,61 @@
+# path-cache.es -- Cache paths as functions.
+#
+# When a binary $prog is searched for in $path and run, then fn-$prog is set to
+# $path (if not already defined).  This short-circuits the process of searching
+# path for that $prog in the future, which can be a performance win when path
+# searching is slow for whatever reason.  Many Bourne-based shells do something
+# similar under the name "hashing".
+#
+# Caching the path also adds $prog to the path-cache variable.  This is used by
+# the recache function described below.  It can also be inspected by the user,
+# but should probably not be modified by anything other than recache.
+#
+# This implementation avoids redefining any already-defined functions, which may
+# be a bit over-conservative, but seems less surprising than the alternative.
+#
+# This is adapted from a version originally written by Paul Haahr.
+# See esrc.haahr in the examples directory for more of his setup.
+
+let (search = $fn-%pathsearch)
+fn %pathsearch prog {
+	let (path = <={$search $prog}) {
+		if {~ $path /*} {
+			if {~ $#(fn-$prog) 0} {
+				path-cache = $path-cache $prog
+				fn-$prog = $path
+			}
+		}
+		result $path
+	}
+}
+
+# recache takes a list of binaries.  For each one, if that prog is in
+# $path-cache, then fn-$prog is set to () and $prog is removed from
+# path-cache.  If recache is called with no arguments, then the entire cache is
+# reset.
+
+fn recache progs {
+	let (cache = $path-cache; new-cache = ()) {
+		if {~ $#progs 0} {
+			progs = $path-cache
+		}
+		for (p = $cache) {
+			if {~ $p $progs} {
+				fn-$p = ()
+			} {
+				new-cache = $new-cache $p
+			}
+		}
+		path-cache = $new-cache
+	}
+}
+
+# path-cache and the fn-$progs defined by %pathsearch, are exported to the
+# environment, under the assumption that subshells will also benefit from the
+# already built cache.
+
+# TODO: recache should be called if PATH is changed.  Exported path-cache
+# complicates this a bit (consider es calling a binary which changes PATH and
+# then calls es again).
+
+path-cache = ()

--- a/share/path-cache.es
+++ b/share/path-cache.es
@@ -60,7 +60,7 @@ fn precache progs {
 	for (p = $progs) {
 		catch @ e type msg {
 			if {~ $e error} {
-				echo >[1=2] $p: $msg
+				echo >[1=2] $msg
 			} {
 				throw $e $type $msg
 			}

--- a/share/status.es
+++ b/share/status.es
@@ -1,0 +1,15 @@
+# status.es -- Make $status available in the interactive loop.
+#
+# With this, users can get the return value of the previous command invoked
+# at the REPL.  This corresponds with $? in Bourne-compatible shells, or $status
+# in rc.  Modifying $status is not very useful.
+
+let (loop = $fn-%interactive-loop)
+fn %interactive-loop {
+	let (d = $fn-%dispatch)
+	local (
+		noexport = $noexport status
+		status = <=true
+		fn %dispatch {status = <={$d $*}}
+	) $loop $*
+}

--- a/share/status.es
+++ b/share/status.es
@@ -3,6 +3,15 @@
 # With this, users can get the return value of the previous command invoked
 # at the REPL.  This corresponds with $? in Bourne-compatible shells, or $status
 # in rc.  Modifying $status is not very useful.
+#
+# One unique limitation of this $status is that it doesn't understand commands
+# like:
+#
+# 	false; echo $status
+#
+# This will reflect the return value of the previous command typed at the REPL,
+# not the false.  Because of this, users should, in general, still prefer to use
+# <= whenever possible.
 
 let (loop = $fn-%interactive-loop)
 fn %interactive-loop {

--- a/share/status.es
+++ b/share/status.es
@@ -4,8 +4,8 @@
 # at the REPL.  This corresponds with $? in Bourne-compatible shells, or $status
 # in rc.  Modifying $status is not very useful.
 #
-# One unique limitation of this $status is that it doesn't understand commands
-# like:
+# One unique limitation of this $status is that it doesn't understand groups of
+# commands like:
 #
 # 	false; echo $status
 #


### PR DESCRIPTION
This change adds five scripts which represent commonly-desired features to _es_ which, by default, probably shouldn't live in the shell, but also should be available for those who want them.

The novel aspect here is these scripts are installed by `make install` to `$prefix/share/es` (and, I imagine, should be packaged along with the binary as well).  They are also mentioned in the man page.

A note to reviewers: I don't intend these to be "show off jpco's setup" scripts.  That would go in `examples/` (not to mention I don't even use half of these most of the time!).  The intent here is to be authoritative: if you want this feature, this is probably how you'd want it.  So, if you _do_ happen to use any of these features, would you be willing to switch to the "canonical" versions provided here?  If not, why not?  Is there something that could be changed that would get you to do so?

This PR implements #123, and obsoletes #66.  It also, after the fact, addresses #33 and #108.

Note that `cdpath.es` requires #130 (or a related fix) to work in many cases.  The `cache-path` behavior in `path-cache.es` might also.  It is possible to add tests for these scripts; I haven't in this PR mostly due to laziness.