### PR TITLE
Reduce performance impact of reading history.

### DIFF
--- a/doc/es.1
+++ b/doc/es.1
@@ -2741,6 +2741,14 @@ and
 .Cr TERMCAP
 variables to notify the line editing packages that the terminal
 configuration has changed.
+Similarly,
+.Cr setmaxhistorylength
+is used as the settor function for the
+.Cr max-history-length
+variable, which signals to the
+.I readline
+library how much of the history file should be read into the in-memory
+history log.
 .PP
 Several primitives are not directly associated with other function.
 They are:

--- a/es.h
+++ b/es.h
@@ -284,8 +284,9 @@ extern Tree *parse(char *esprompt1, char *esprompt2);
 extern Tree *parsestring(const char *str);
 extern void sethistory(char *file);
 extern Boolean isinteractive(void);
-#if ABUSED_GETENV
 #if READLINE
+extern void setmaxhistorylength(int length);
+#if ABUSED_GETENV
 extern void initgetenv(void);
 #endif
 #endif

--- a/initial.es
+++ b/initial.es
@@ -720,6 +720,16 @@ if {~ <=$&primitives resetterminal} {
 	set-TERMCAP	= @ { $&resetterminal; result $* }
 }
 
+#	The primitive $&setmaxhistorylength is another readline-only primitive
+#	which limits the length of the in-memory history log, to reduce memory
+#	size implications of a large history file.  Setting max-history-length
+#	to 0, or unsetting it, makes the in-memory history unlimited in size.
+
+if {~ <=$&primitives setmaxhistorylength} {
+	set-max-history-length = $&setmaxhistorylength
+	max-history-length = 5000
+}
+
 #
 # Variables
 #

--- a/initial.es
+++ b/initial.es
@@ -721,14 +721,16 @@ if {~ <=$&primitives resetterminal} {
 }
 
 #	The primitive $&setmaxhistorylength is another readline-only primitive
-#	which limits the length of the in-memory history log, to reduce memory
+#	which limits the length of the in-memory history list, to reduce memory
 #	size implications of a large history file.  Setting max-history-length
-#	to 0, or unsetting it, makes the in-memory history unlimited in size.
+#	to 0 clears the history list and disables adding anything more to it.
+#	Unsetting max-history-length allows the history list to grow unbounded.
 
 if {~ <=$&primitives setmaxhistorylength} {
 	set-max-history-length = $&setmaxhistorylength
 	max-history-length = 5000
 }
+
 
 #
 # Variables

--- a/input.c
+++ b/input.c
@@ -109,7 +109,7 @@ static void loghistory(const char *cmd, size_t len) {
 	ewrite(historyfd, cmd, len);
 }
 
-#if READLINE
+#if HAVE_READLINE
 /* Manage maximum in-memory history length.  This has speed & memory
  * implications to which different users have different tolerances, so let them
  * pick. */
@@ -142,7 +142,7 @@ static void reload_history(void) {
 
 /* sethistory -- change the file for the history log */
 extern void sethistory(char *file) {
-#if READLINE
+#if HAVE_READLINE
 	/* make sure the old file has a chance to get loaded */
 	if (reloadhistory)
 		reload_history();

--- a/input.c
+++ b/input.c
@@ -109,6 +109,7 @@ static void loghistory(const char *cmd, size_t len) {
 	ewrite(historyfd, cmd, len);
 }
 
+#if READLINE
 static void reload_history(void) {
 	/* Attempt to populate readline history with new history file. */
 	if (!history_is_stifled())
@@ -118,11 +119,14 @@ static void reload_history(void) {
 
 	reloadhistory = FALSE;
 }
+#endif
 
 /* sethistory -- change the file for the history log */
 extern void sethistory(char *file) {
+#if READLINE
 	if (reloadhistory)
 		reload_history();
+#endif
 	if (historyfd != -1) {
 		close(historyfd);
 		historyfd = -1;

--- a/input.c
+++ b/input.c
@@ -114,6 +114,7 @@ static void reload_history(void) {
 	/* Attempt to populate readline history with new history file. */
 	if (!history_is_stifled())
 		stifle_history(5000);
+	clear_history();
 	read_history(history);
 	using_history();
 
@@ -123,10 +124,6 @@ static void reload_history(void) {
 
 /* sethistory -- change the file for the history log */
 extern void sethistory(char *file) {
-#if READLINE
-	if (reloadhistory)
-		reload_history();
-#endif
 	if (historyfd != -1) {
 		close(historyfd);
 		historyfd = -1;

--- a/input.c
+++ b/input.c
@@ -110,10 +110,22 @@ static void loghistory(const char *cmd, size_t len) {
 }
 
 #if READLINE
+/* Manage maximum in-memory history length.  This has speed & memory
+ * implications to which different users have different tolerances, so let them
+ * pick. */
+extern void setmaxhistorylength(int len) {
+	static int currenthistlen = 0; /* unlimited */
+	if (len != currenthistlen) {
+		if (len == 0)
+			unstifle_history();
+		else
+			stifle_history(len);
+		currenthistlen = len;
+	}
+}
+
 static void reload_history(void) {
 	/* Attempt to populate readline history with new history file. */
-	if (!history_is_stifled())
-		stifle_history(5000);
 	clear_history();
 	read_history(history);
 	using_history();

--- a/input.c
+++ b/input.c
@@ -114,12 +114,18 @@ static void loghistory(const char *cmd, size_t len) {
  * implications to which different users have different tolerances, so let them
  * pick. */
 extern void setmaxhistorylength(int len) {
-	static int currenthistlen = 0; /* unlimited */
+	static int currenthistlen = -1; /* unlimited */
 	if (len != currenthistlen) {
-		if (len == 0)
+		switch (len) {
+		case -1:
 			unstifle_history();
-		else
+			break;
+		case 0:
+			clear_history();
+			/* fallthrough */
+		default:
 			stifle_history(len);
+		}
 		currenthistlen = len;
 	}
 }
@@ -136,6 +142,11 @@ static void reload_history(void) {
 
 /* sethistory -- change the file for the history log */
 extern void sethistory(char *file) {
+#if READLINE
+	/* make sure the old file has a chance to get loaded */
+	if (reloadhistory)
+		reload_history();
+#endif
 	if (historyfd != -1) {
 		close(historyfd);
 		historyfd = -1;

--- a/input.c
+++ b/input.c
@@ -122,7 +122,7 @@ extern void setmaxhistorylength(int len) {
 			break;
 		case 0:
 			clear_history();
-			/* fallthrough */
+			FALLTHROUGH;
 		default:
 			stifle_history(len);
 		}

--- a/input.c
+++ b/input.c
@@ -126,8 +126,8 @@ extern void setmaxhistorylength(int len) {
 
 static void reload_history(void) {
 	/* Attempt to populate readline history with new history file. */
-	clear_history();
-	read_history(history);
+	if (history != NULL)
+		read_history(history);
 	using_history();
 
 	reloadhistory = FALSE;

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -280,6 +280,23 @@ PRIM(setmaxevaldepth) {
 }
 
 #if READLINE
+PRIM(setmaxhistorylength) {
+	char *s;
+	int n;
+	if (list == NULL) {
+		setmaxhistorylength(0); /* unlimited */
+		return NULL;
+	}
+	if (list->next != NULL)
+		fail("$&setmaxhistorylength", "usage: $&setmaxhistorylength [limit]");
+	Ref(List *, lp, list);
+	n = (int)strtol(getstr(lp->term), &s, 0);
+	if (n < 0 || (s != NULL && *s != '\0'))
+		fail("$&setmaxhistorylength", "max-history-length must be set to a positive integer");
+	setmaxhistorylength(n);
+	RefReturn(lp);
+}
+
 PRIM(resetterminal) {
 	resetterminal = TRUE;
 	return true;
@@ -317,6 +334,7 @@ extern Dict *initprims_etc(Dict *primdict) {
 	X(setmaxevaldepth);
 #if READLINE
 	X(resetterminal);
+	X(setmaxhistorylength);
 #endif
 	return primdict;
 }

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -284,7 +284,7 @@ PRIM(setmaxhistorylength) {
 	char *s;
 	int n;
 	if (list == NULL) {
-		setmaxhistorylength(0); /* unlimited */
+		setmaxhistorylength(-1); /* unlimited */
 		return NULL;
 	}
 	if (list->next != NULL)


### PR DESCRIPTION
1. Do not do so unless actually necessary (that is, either when we call `callreadline()` or when we change the value again later).
2. Shrink stifle_history size to 5000.

Both of these speed up startup quite a bit, and both also reduce memory usage quite a bit as well.  The first one is an unambiguous win; the second may be unfortunate for those folks who want to search some very old commands.  Does anyone want a `$max-history-size` variable so as to have a choice in the matter?

Also, I'll repeat my question from the linked issue: Should we clear the in-memory history when $history is changed?

This fixes #133 (edit: it also fixes #135).