### PR TITLE
Fix rangematch() and a couple of undefined behavior issues

### DIFF
--- a/dict.c
+++ b/dict.c
@@ -27,7 +27,7 @@ static unsigned long strhash2(const char *str1, const char *str2) {
 		} \
 	}
 
-	int c;
+	unsigned int c;
 	unsigned long n = 0;
 	unsigned char *s = (unsigned char *) str1;
 	assert(str1 != NULL);

--- a/fd.c
+++ b/fd.c
@@ -105,8 +105,10 @@ extern int fdmap(int fd) {
 
 /* remapfds -- apply the fd map to the current file descriptor table */
 static void remapfds(void) {
-	Defer *defer, *defend = &deftab[defcount];
-	for (defer = deftab; defer < defend; defer++) {
+	Defer *defer, *defend;
+	if (deftab == NULL)
+		return;
+	for (defer = deftab, defend = &deftab[defcount]; defer < defend; defer++) {
 		unregisterfd(&defer->realfd);
 		dodeferred(defer->realfd, defer->userfd);
 	}

--- a/match.c
+++ b/match.c
@@ -21,6 +21,7 @@ enum { RANGE_FAIL = -1, RANGE_ERROR = -2 };
 
 #define	ISQUOTED(q, n)	((q) == QUOTED || ((q) != UNQUOTED && (q)[n] == 'q'))
 #define TAILQUOTE(q, n) ((q) == UNQUOTED ? UNQUOTED : ((q) + (n)))
+#define QADVANCE(q, n) ((q) += (((q) == QUOTED || (q) == UNQUOTED) ? 0 : (n)))
 
 /* rangematch -- match a character against a character class */
 static int rangematch(const char *p, const char *q, char c) {
@@ -28,15 +29,15 @@ static int rangematch(const char *p, const char *q, char c) {
 	Boolean neg;
 	Boolean matched = FALSE;
 	if (*p == '~' && !ISQUOTED(q, 0)) {
-		p++, q++;
+		p++, QADVANCE(q, 1);
 	    	neg = TRUE;
 	} else
 		neg = FALSE;
 	if (*p == ']' && !ISQUOTED(q, 0)) {
-		p++, q++;
+		p++, QADVANCE(q, 1);
 		matched = (c == ']');
 	}
-	for (; *p != ']' || ISQUOTED(q, 0); p++, q++) {
+	for (; *p != ']' || ISQUOTED(q, 0); p++, QADVANCE(q, 1)) {
 		if (*p == '\0')
 			return RANGE_ERROR;	/* bad syntax */
 		if (p[1] == '-' && !ISQUOTED(q, 1) && ((p[2] != ']' && p[2] != '\0') || ISQUOTED(q, 2))) {
@@ -44,7 +45,7 @@ static int rangematch(const char *p, const char *q, char c) {
 			if (c >= *p && c <= p[2])
 				matched = TRUE;
 			p += 2;
-			q += 2;
+			QADVANCE(q, 2);
 		} else if (*p == c)
 			matched = TRUE;
 	}


### PR DESCRIPTION
This fixes an out-of-bounds read operation in `rangematch()`, a bit-shift operation on a negative value (undefined behavior), and pointer arithmetic on a null pointer (undefined behavior).