### PR TITLE
Fix VPATH builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -85,12 +85,12 @@ MANIFEST:
 
 install : es
 	$(MKDIR_P) $(DESTDIR)$(bindir)
-	$(INSTALL) -s $(srcdir)/es $(DESTDIR)$(bindir)
+	$(INSTALL) -s es $(DESTDIR)$(bindir)
 	$(MKDIR_P) $(DESTDIR)$(mandir)/man1
 	$(INSTALL) $(srcdir)/doc/es.1 $(DESTDIR)$(mandir)/man1
 
 test	: es $(testdir)/test.es
-	$(srcdir)/es -s < $(testdir)/test.es $(testdir)/tests/*
+	./es -s < $(testdir)/test.es $(testdir)/tests/*
 
 src	:
 	@echo ${OTHER} ${CFILES} ${HFILES}


### PR DESCRIPTION
The VPATH feature used in the Makefile allows building _es_ outside `$(srcdir)`.
Without this, both the `test` and `install` targets fail due to their use of `$(srcdir)/es` when the current directory differs from `$(srcdir)`.