### PR TITLE
Enable -Wclobbered and resolve all warnings.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,7 @@ MKDIR_P = @MKDIR_P@
 ## Bison is generating incorrect parsers.  So do not use, for now
 # YACC = @YACC@
 
-CFLAGS	= $(ADDCFLAGS) -I. -I$(srcdir) -W -Wall -Wdeclaration-after-statement -Wno-clobbered @READLINE_CFLAGS@ @CFLAGS@
+CFLAGS	= $(ADDCFLAGS) -I. -I$(srcdir) -W -Wall -Wdeclaration-after-statement @READLINE_CFLAGS@ @CFLAGS@
 LDFLAGS	= $(ADDLDFLAGS) @LDFLAGS@
 LIBS	= $(ADDLIBS) @READLINE_LIBS@ @LIBS@
 

--- a/input.c
+++ b/input.c
@@ -200,7 +200,8 @@ static int eoffill(Input *in) {
 
 #if HAVE_READLINE
 /* callreadline -- readline wrapper */
-static char *callreadline(char *prompt) {
+static char *callreadline(char *prompt0) {
+	char *volatile prompt = prompt0;
 	char *r;
 	if (prompt == NULL)
 		prompt = ""; /* bug fix for readline 2.0 */

--- a/main.c
+++ b/main.c
@@ -97,8 +97,9 @@ static Noreturn usage(void) {
 
 
 /* main -- initialize, parse command arguments, and start running */
-int main(int argc, char **argv) {
+int main(int argc, char **argv0) {
 	int c;
+	char **volatile argv = argv0;
 
 	volatile int runflags = 0;		/* -[einvxL] */
 	volatile Boolean protected = FALSE;	/* -p */

--- a/var.c
+++ b/var.c
@@ -234,7 +234,7 @@ extern void varpush(Push *push, char *name, List *defn) {
 
 extern void varpop(Push *push) {
 	Var *var;
-	List *except = NULL;
+	List *volatile except = NULL;
 
 	assert(pushlist == push);
 	assert(rootlist == &push->defnroot);


### PR DESCRIPTION
Fairly mechanical.  `char **volatile argv` is certainly a sign your program is doing something good.