### PR TITLE
Simplify ASTs generated from redundant lists and thunks

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -70,27 +70,27 @@ cmd	:		%prec LET		{ $$ = NULL; }
 	| EXTRACT word words			{ $$ = mk(nExtract, $2, $3); }
 	| MATCH word nl '(' cases ')'		{ $$ = mkmatch($2, $5); }
 
-cases	: case				{ $$ = treecons2($1, NULL); }
-	| cases ';' case		{ $$ = treeconsend2($1, $3); }
-	| cases NL case			{ $$ = treeconsend2($1, $3); }
+cases	: case				{ $$ = treecons($1, NULL); }
+	| cases ';' case		{ $$ = treeconsend($1, $3); }
+	| cases NL case			{ $$ = treeconsend($1, $3); }
 
 case	:				{ $$ = NULL; }
-	| word first			{ $$ = mk(nList, $1, thunkify($2)); }
+	| word first			{ $$ = mk(nMatch, $1, thunkify($2)); }
 
-simple	: first				{ $$ = treecons2($1, NULL); }
+simple	: first				{ $$ = treecons($1, NULL); }
 	| first args			{ $$ = firstprepend($1, $2); }
 
-args	: word				{ $$ = treecons2($1, NULL); }
+args	: word				{ $$ = treecons($1, NULL); }
 	| redir				{ $$ = redirappend(NULL, $1); }
-	| args word			{ $$ = treeconsend2($1, $2); }
+	| args word			{ $$ = treeconsend($1, $2); }
 	| args redir			{ $$ = redirappend($1, $2); }
 
 redir	: DUP				{ $$ = $1; }
 	| REDIR word			{ $$ = mkredir($1, $2); }
 
-bindings: binding			{ $$ = treecons2($1, NULL); }
-	| bindings ';' binding		{ $$ = treeconsend2($1, $3); }
-	| bindings NL binding		{ $$ = treeconsend2($1, $3); }
+bindings: binding			{ $$ = treecons($1, NULL); }
+	| bindings ';' binding		{ $$ = treeconsend($1, $3); }
+	| bindings NL binding		{ $$ = treeconsend($1, $3); }
 
 binding	:				{ $$ = NULL; }
 	| fn				{ $$ = $1; }

--- a/syntax.h
+++ b/syntax.h
@@ -9,9 +9,7 @@
 extern Tree errornode;
 
 extern Tree *treecons(Tree *car, Tree *cdr);
-extern Tree *treecons2(Tree *car, Tree *cdr);
 extern Tree *treeconsend(Tree *p, Tree *q);
-extern Tree *treeconsend2(Tree *p, Tree *q);
 extern Tree *treeappend(Tree *head, Tree *tail);
 extern Tree *thunkify(Tree *tree);
 


### PR DESCRIPTION
This PR removes the confusing `treecons`/`treecons2` and `treeconsend`/`treeconsend2` distinction by always using the `2` versions of the functions (and giving them the non-`2` names).  This makes `parse.y`, in my opinion, much simpler to understand.

The user-visible impact of this change is that _es_ now more robustly deduplicates thunks:
```
; ./es.old -c 'echo {(({({{}})}))}'
{{{}}}
; ./es.new -c 'echo {(({({{}})}))}'
{}
```
Additionally, this removes several other (very minor) cases of redundancy in ASTs:
```
; ./es.old -Lnc '$(a ((b) c))'
(list (var (list (word "a") (list (list (word "b")) (word "c")))))
; ./es.new -Lnc '$(a ((b) c))'
(list (var (list (word "a") (word "b") (word "c"))))
; ./es.old -Lnc 'if (({false} {false}) {true})'
(list (word "if") (list (list (thunk (list (word "false"))) (thunk (list (word "false")))) (thunk (list (word "true")))))
; ./es.new -Lnc 'if (({false} {false}) {true})'
(list (word "if") (thunk (list (word "false"))) (thunk (list (word "false"))) (thunk (list (word "true"))))
```

Fixes #139.