### PR TITLE
Use POSIX-compatible setpgid()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_TYPE_GETGROUPS
 AC_FUNC_MMAP
 
 AC_CHECK_FUNCS(strerror strtol lstat setrlimit sigrelse sighold sigaction \
-sysconf setsid sigsetjmp getrusage)
+sysconf sigsetjmp getrusage)
 
 AC_CACHE_CHECK(for an abused getenv, es_cv_abused_getenv,
 AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/doc/es.1
+++ b/doc/es.1
@@ -2106,8 +2106,6 @@ This builtin is useful for making
 behave like a job-control shell in a hostile environment.
 One example is the NeXT Terminal program, which implicitly assumes
 that each shell it forks will put itself into a new process group.
-Note that the controlling tty for the process must be on standard error
-(file descriptor 2) when this operation is run.
 .TP
 .Cr "result \fIvalue ...\fP"
 Returns its arguments.

--- a/es.h
+++ b/es.h
@@ -370,6 +370,7 @@ extern void unblocksignals(void);
 
 typedef enum { oOpen, oCreate, oAppend, oReadWrite, oReadCreate, oReadAppend } OpenKind;
 extern int eopen(char *name, OpenKind k);
+extern int opentty(void);
 
 
 /* version.c */

--- a/es.h
+++ b/es.h
@@ -223,8 +223,9 @@ extern char *checkexecutable(char *file);
 
 extern Boolean hasforked;
 extern int efork(Boolean parent, Boolean background);
-extern void newpgrp(void);
-extern void tctakepgrp(void);
+extern pid_t newpgrp(void);
+extern pid_t spgrp(pid_t pgid);
+extern int tctakepgrp(void);
 extern void initpgrp(void);
 extern int ewait(int pid, Boolean interruptible, void *rusage);
 #define	ewaitfor(pid)	ewait(pid, FALSE, NULL)

--- a/es.h
+++ b/es.h
@@ -225,8 +225,16 @@ extern Boolean hasforked;
 extern int efork(Boolean parent, Boolean background);
 extern void newpgrp(void);
 extern void tctakepgrp(void);
+extern void initpgrp(void);
 extern int ewait(int pid, Boolean interruptible, void *rusage);
 #define	ewaitfor(pid)	ewait(pid, FALSE, NULL)
+
+#if JOB_PROTECT
+extern void tcreturnpgrp(void);
+extern Noreturn esexit(int);
+#else
+#define	esexit(n)	(exit(n))
+#endif
 
 
 /* dict.c */

--- a/es.h
+++ b/es.h
@@ -223,7 +223,6 @@ extern char *checkexecutable(char *file);
 
 extern Boolean hasforked;
 extern int efork(Boolean parent, Boolean background);
-extern pid_t newpgrp(void);
 extern pid_t spgrp(pid_t pgid);
 extern int tctakepgrp(void);
 extern void initpgrp(void);

--- a/es.h
+++ b/es.h
@@ -223,6 +223,8 @@ extern char *checkexecutable(char *file);
 
 extern Boolean hasforked;
 extern int efork(Boolean parent, Boolean background);
+extern void newpgrp(void);
+extern void tctakepgrp(void);
 extern int ewait(int pid, Boolean interruptible, void *rusage);
 #define	ewaitfor(pid)	ewait(pid, FALSE, NULL)
 

--- a/eval.c
+++ b/eval.c
@@ -19,7 +19,7 @@ static Noreturn failexec(char *file, List *args) {
 		errno = olderror;
 	}
 	eprint("%s: %s\n", file, esstrerror(errno));
-	exit(1);
+	esexit(1);
 }
 
 /* forkexec -- fork (if necessary) and exec */
@@ -469,7 +469,7 @@ restart:
 done:
 	--evaldepth;
 	if ((flags & eval_exitonfalse) && !istrue(list))
-		exit(exitstatus(list));
+		esexit(exitstatus(list));
 	RefEnd2(funcname, binding);
 	RefReturn(list);
 }

--- a/gc.c
+++ b/gc.c
@@ -88,7 +88,7 @@ static void *take(size_t n) {
 	kern_return_t error = vm_allocate(task_self(), &addr, n, TRUE);
 	if (error != KERN_SUCCESS) {
 		mach_error("vm_allocate", error);
-		exit(1);
+		esexit(1);
 	}
 	memset((void *) addr, 0xC9, n);
 	return (void *) addr;
@@ -99,7 +99,7 @@ static void release(void *p, size_t n) {
 	kern_return_t error = vm_deallocate(task_self(), (vm_address_t) p, n);
 	if (error != KERN_SUCCESS) {
 		mach_error("vm_deallocate", error);
-		exit(1);
+		esexit(1);
 	}
 }
 
@@ -108,7 +108,7 @@ static void invalidate(void *p, size_t n) {
 	kern_return_t error = vm_protect(task_self(), (vm_address_t) p, n, FALSE, 0);
 	if (error != KERN_SUCCESS) {
 		mach_error("vm_protect 0", error);
-		exit(1);
+		esexit(1);
 	}
 }
 
@@ -118,7 +118,7 @@ static void revalidate(void *p, size_t n) {
 		vm_protect(task_self(), (vm_address_t) p, n, FALSE, VM_PROT_READ|VM_PROT_WRITE);
 	if (error != KERN_SUCCESS) {
 		mach_error("vm_protect VM_PROT_READ|VM_PROT_WRITE", error);
-		exit(1);
+		esexit(1);
 	}
 	memset(p, 0x4F, n);
 }

--- a/main.c
+++ b/main.c
@@ -98,7 +98,7 @@ static Noreturn usage(void) {
 
 /* main -- initialize, parse command arguments, and start running */
 int main(int argc, char **argv0) {
-	int c;
+	int c, status = 0;
 	char **volatile argv = argv0;
 
 	volatile int runflags = 0;		/* -[einvxL] */
@@ -183,6 +183,7 @@ getopt_done:
 		initpath();
 		initpid();
 		initsignals(runflags & run_interactive, allowquit);
+		initpgrp();
 		hidevariables();
 		initenv(environ, protected);
 	
@@ -195,31 +196,40 @@ getopt_done:
 			argp = argp->next;
 			if ((fd = eopen(file, oOpen)) == -1) {
 				eprint("%s: %s\n", file, esstrerror(errno));
-				return 1;
+				status = 1;
+				goto return_main;
 			}
 			vardef("*", NULL, argp);
 			vardef("0", NULL, mklist(mkstr(file), NULL));
-			return exitstatus(runfd(fd, file, runflags));
+			status = exitstatus(runfd(fd, file, runflags));
+			goto return_main;
 		}
 	
 		vardef("*", NULL, argp);
 		vardef("0", NULL, mklist(mkstr(argv[0]), NULL));
 		if (cmd != NULL)
-			return exitstatus(runstring(cmd, NULL, runflags));
-		return exitstatus(runfd(0, "stdin", runflags));
+			status = exitstatus(runstring(cmd, NULL, runflags));
+		else
+			status = exitstatus(runfd(0, "stdin", runflags));
 
 	CatchException (e)
 
-		if (termeq(e->term, "exit"))
-			return exitstatus(e->next);
-		else if (termeq(e->term, "error"))
+		if (termeq(e->term, "exit")) {
+			status = exitstatus(e->next);
+			goto return_main;
+		} else if (termeq(e->term, "error"))
 			eprint("%L\n",
 			       e->next == NULL ? NULL : e->next->next,
 			       " ");
 		else if (!issilentsignal(e))
 			eprint("uncaught exception: %L\n", e, " ");
-		return 1;
+		status = 1;
 
 	EndExceptionHandler
 	RefEnd3(argp, args, cmd);
+return_main:
+#if JOB_PROTECT
+	tcreturnpgrp();
+#endif
+	return status;
 }

--- a/open.c
+++ b/open.c
@@ -28,3 +28,7 @@ extern int eopen(char *name, OpenKind k) {
 	assert((unsigned) k < arraysize(mode_masks));
 	return open(name, mode_masks[k], 0666);
 }
+
+extern int opentty(void) {
+	return open("/dev/tty", O_RDWR|O_NONBLOCK);
+}

--- a/open.c
+++ b/open.c
@@ -8,6 +8,9 @@
 extern int open(const char *, int, ...);
 #endif
 
+#define	MIN_ttyfd	3
+
+
 /*
  * Opens a file with the necessary flags.  Assumes the following order:
  *	typedef enum {
@@ -30,5 +33,16 @@ extern int eopen(char *name, OpenKind k) {
 }
 
 extern int opentty(void) {
-	return open("/dev/tty", O_RDWR|O_NONBLOCK);
+	int e = 0, old, fd = 2;
+	if (isatty(fd))
+		return fcntl(fd, F_DUPFD, MIN_ttyfd);
+	old = open("/dev/tty", O_RDWR|O_NONBLOCK);
+	fd = fcntl(old, F_DUPFD, MIN_ttyfd);
+	if (fd == -1)
+		e = errno;
+	close(old);
+	if (e != 0)
+		errno = e;
+	assert(fd < 0 || fd >= MIN_ttyfd);
+	return fd;
 }

--- a/prim-io.c
+++ b/prim-io.c
@@ -170,7 +170,7 @@ REDIR(here) {
 	if ((pid = pipefork(p, NULL)) == 0) {		/* child that writes to pipe */
 		close(p[0]);
 		fprint(p[1], "%L", doc, "");
-		exit(0);
+		esexit(0);
 	}
 
 	close(p[1]);
@@ -219,7 +219,7 @@ PRIM(pipe) {
 				mvfd(p[1], fd);
 				close(p[0]);
 			}
-			exit(exitstatus(eval1(list->term, evalflags | eval_inchild)));
+			esexit(exitstatus(eval1(list->term, evalflags | eval_inchild)));
 		}
 		pids[n++] = pid;
 		close(inpipe);
@@ -240,7 +240,7 @@ PRIM(pipe) {
 		result = mklist(t, result);
 	} while (0 < n);
 	if (evalflags & eval_inchild)
-		exit(exitstatus(result));
+		esexit(exitstatus(result));
 	RefReturn(result);
 }
 
@@ -262,7 +262,7 @@ PRIM(readfrom) {
 	if ((pid = pipefork(p, NULL)) == 0) {
 		close(p[0]);
 		mvfd(p[1], 1);
-		exit(exitstatus(eval1(input, evalflags &~ eval_inchild)));
+		esexit(exitstatus(eval1(input, evalflags &~ eval_inchild)));
 	}
 
 	close(p[1]);
@@ -302,7 +302,7 @@ PRIM(writeto) {
 	if ((pid = pipefork(p, NULL)) == 0) {
 		close(p[1]);
 		mvfd(p[0], 0);
-		exit(exitstatus(eval1(output, evalflags &~ eval_inchild)));
+		esexit(exitstatus(eval1(output, evalflags &~ eval_inchild)));
 	}
 
 	close(p[0]);
@@ -360,7 +360,7 @@ PRIM(backquote) {
 	if ((pid = pipefork(p, NULL)) == 0) {
 		mvfd(p[1], 1);
 		close(p[0]);
-		exit(exitstatus(eval(lp, NULL, evalflags | eval_inchild)));
+		esexit(exitstatus(eval(lp, NULL, evalflags | eval_inchild)));
 	}
 
 	close(p[1]);

--- a/prim-sys.c
+++ b/prim-sys.c
@@ -23,10 +23,15 @@
 #include <sys/stat.h>
 
 PRIM(newpgrp) {
+	pid_t pgid;
 	if (list != NULL)
 		fail("$&newpgrp", "usage: newpgrp");
-	newpgrp();
-	tctakepgrp();
+	pgid = newpgrp();
+	if (tctakepgrp() != 0) {
+		int e = errno;
+		spgrp(pgid);
+		fail("$&newpgrp", "newpgrp: %s", esstrerror(e));
+	}
 	return ltrue;
 }
 

--- a/prim-sys.c
+++ b/prim-sys.c
@@ -23,12 +23,12 @@
 #include <sys/stat.h>
 
 PRIM(newpgrp) {
+	int e;
 	pid_t pgid;
 	if (list != NULL)
 		fail("$&newpgrp", "usage: newpgrp");
-	pgid = newpgrp();
-	if (tctakepgrp() != 0) {
-		int e = errno;
+	pgid = spgrp(getpid());
+	if ((e = tctakepgrp()) != 0) {
 		spgrp(pgid);
 		fail("$&newpgrp", "newpgrp: %s", esstrerror(e));
 	}

--- a/prim-sys.c
+++ b/prim-sys.c
@@ -23,21 +23,10 @@
 #include <sys/stat.h>
 
 PRIM(newpgrp) {
-	int pid;
 	if (list != NULL)
 		fail("$&newpgrp", "usage: newpgrp");
-	pid = getpid();
-	setpgid(pid, pid);
-	{
-		Sigeffect sigtstp = esignal(SIGTSTP, sig_ignore);
-		Sigeffect sigttin = esignal(SIGTTIN, sig_ignore);
-		Sigeffect sigttou = esignal(SIGTTOU, sig_ignore);
-		if (tcsetpgrp(2, pid) != 0)
-			uerror("tcsetpgrp");
-		esignal(SIGTSTP, sigtstp);
-		esignal(SIGTTIN, sigttin);
-		esignal(SIGTTOU, sigttou);
-	}
+	newpgrp();
+	tctakepgrp();
 	return ltrue;
 }
 

--- a/prim-sys.c
+++ b/prim-sys.c
@@ -39,7 +39,7 @@ PRIM(background) {
 			setpgid(0, 0);
 #endif
 		mvfd(eopen("/dev/null", oOpen), 0);
-		exit(exitstatus(eval(list, NULL, evalflags | eval_inchild)));
+		esexit(exitstatus(eval(list, NULL, evalflags | eval_inchild)));
 	}
 	return mklist(mkstr(str("%d", pid)), NULL);
 }
@@ -48,7 +48,7 @@ PRIM(fork) {
 	int pid, status;
 	pid = efork(TRUE, FALSE);
 	if (pid == 0)
-		exit(exitstatus(eval(list, NULL, evalflags | eval_inchild)));
+		esexit(exitstatus(eval(list, NULL, evalflags | eval_inchild)));
 	status = ewaitfor(pid);
 	SIGCHK();
 	printstatus(0, status);
@@ -297,7 +297,7 @@ PRIM(time) {
 	t0 = time(NULL);
 	pid = efork(TRUE, FALSE);
 	if (pid == 0)
-		exit(exitstatus(eval(lp, NULL, evalflags | eval_inchild)));
+		esexit(exitstatus(eval(lp, NULL, evalflags | eval_inchild)));
 	status = ewait(pid, FALSE, &r);
 	t1 = time(NULL);
 	SIGCHK();
@@ -332,7 +332,7 @@ PRIM(time) {
 		t0 = times(&tms);
 		pid = efork(TRUE, FALSE);
 		if (pid == 0)
-			exit(exitstatus(eval(lp, NULL, evalflags | eval_inchild)));
+			esexit(exitstatus(eval(lp, NULL, evalflags | eval_inchild)));
 
 		status = ewaitfor(pid);
 		t1 = times(&tms);
@@ -349,7 +349,7 @@ PRIM(time) {
 			tms.tms_cstime / ticks, ((tms.tms_cstime * 10) / ticks) % 10,
 			lp, " "
 		);
-		exit(status);
+		esexit(status);
 	}
 	status = ewaitfor(pid);
 	SIGCHK();

--- a/print.c
+++ b/print.c
@@ -292,7 +292,7 @@ static void fprint_flush(Format *format, size_t UNUSED more) {
 		if (written == -1) {
 			if (format->u.n != 2)
 				uerror("write");
-			exit(1);
+			esexit(1);
 		}
 		n -= written;
 	}
@@ -346,5 +346,5 @@ extern Noreturn panic VARARGS1(const char *, fmt) {
 	fdprint(&format, 2, fmt);
 	va_end(format.args);
 	eprint("\n");
-	exit(1);
+	esexit(1);
 }

--- a/proc.c
+++ b/proc.c
@@ -73,7 +73,8 @@ static void tcspgrp(pid_t pgid) {
 	Sigeffect tstp = esignal(SIGTSTP, sig_ignore);
 	Sigeffect ttin = esignal(SIGTTIN, sig_ignore);
 	Sigeffect ttou = esignal(SIGTTOU, sig_ignore);
-	tcsetpgrp(2, pgid);
+	if (tcsetpgrp(2, pgid) != 0)
+		uerror("tcsetpgrp");
 	esignal(SIGTSTP, tstp);
 	esignal(SIGTTIN, ttin);
 	esignal(SIGTTOU, ttou);
@@ -82,7 +83,7 @@ static void tcspgrp(pid_t pgid) {
 extern void tctakepgrp(void) {
 	pid_t tcpgid;
 	tcpgid = tcgetpgrp(2);
-	if (tcpgid != espgid)
+	if (espgid != 0 && tcpgid != espgid)
 		tcspgrp(espgid);
 }
 

--- a/signal.c
+++ b/signal.c
@@ -73,7 +73,7 @@ static void catcher(int sig) {
 #endif
 	if (hasforked)
 		/* exit unconditionally on a signal in a child process */
-		exit(1);
+		esexit(1);
 	if (caught[sig] == 0) {
 		caught[sig] = TRUE;
 		++sigcount;
@@ -279,7 +279,7 @@ extern void sigchk(void) {
 		return;
 	if (hasforked)
 		/* exit unconditionally on a signal in a child process */
-		exit(1);
+		esexit(1);
 
 	for (sig = 0;; sig++) {
 		if (caught[sig] != 0) {

--- a/stdenv.h
+++ b/stdenv.h
@@ -249,7 +249,6 @@ extern int getpagesize(void);
 extern int getpid(void);
 extern int pipe(int p[2]);
 extern int read(int fd, void *buf, size_t n);
-extern int setpgrp(int pid, int pgrp);
 extern int umask(int mask);
 extern int write(int fd, const void *buf, size_t n);
 
@@ -270,23 +269,6 @@ extern int getgroups(int, int *);
 /*
  * hacks to present a standard system call interface
  */
-
-#ifdef HAVE_SETSID
-# define setpgrp(a, b)	setsid()
-#else
-#if defined(linux) || defined(__GLIBC__)
-#include "unistd.h"
-#define setpgrp(a, b)	setpgid(a, b)
-#endif
-
-#if sgi
-#define	setpgrp(a, b)	BSDsetpgrp(a,b)
-#endif
-
-#if HPUX
-#define	setpgrp(a, b)	setpgrp()
-#endif
-#endif
 
 #if !HAVE_LSTAT
 #define	lstat	stat

--- a/test/tests/wait.es
+++ b/test/tests/wait.es
@@ -30,12 +30,11 @@ test 'wait is precise' {
 	}
 }
 
-# TODO: Fix setpgid-related behavior to make this work
-# test 'setpgid' {
-# 	let (pid = <={$&background {./testrun s}}) {
-# 		assert {ps -o pid | grep $pid > /dev/null} 'background process appears in ps'
-# 		kill $pid
-# 		wait $pid >[2] /dev/null
-# 		assert {!{ps -o pid | grep $pid}}
-# 	}
-# }
+test 'setpgid' {
+	let (pid = <={$&background {./testrun s}}) {
+		assert {ps -o pid | grep $pid > /dev/null} 'background process appears in ps'
+		kill $pid
+		wait $pid >[2] /dev/null
+		assert {!{ps -o pid | grep $pid}}
+	}
+}

--- a/util.c
+++ b/util.c
@@ -64,7 +64,7 @@ extern void *ealloc(size_t n) {
 	void *p = malloc(n);
 	if (p == NULL) {
 		uerror("malloc");
-		exit(1);
+		esexit(1);
 	}
 	return p;
 }
@@ -77,7 +77,7 @@ extern void *erealloc(void *p, size_t n) {
 	p = realloc(p, n);
 	if (p == NULL) {
 		uerror("realloc");
-		exit(1);
+		esexit(1);
 	}
 	return p;
 }


### PR DESCRIPTION
This PR is stuff that's a bit difficult to reason about, since outside of job control, process group related changes are basically only visible through side effects.  This description describes the state for all POSIX-compliant OSes (in particular, those with `setsid()`.)

State before:
 - The `$&newpgrp` primitive places _es_ into its own session, and attempts to take the terminal for the new process group implicitly created with the new session, which always quietly fails.
 - If built with `JOB_PROTECT`, then _es_ places every new background process into a new session.  This causes certain "shell-spawning" processes like terminals and window managers to fail to kill those backgrounded processes when they exit.  This can be useful, but is nonstandard and often undesirable.

State after:
 - The `$&newpgrp` primitive places _es_ into a new process group and attempts to take the terminal, which (usually) succeeds, and _es_ complains if it doesn't.
 - If built with `JOB_PROTECT`, then _es_ places every new background process into a new process group, _if_ _es_ is interactive.  In this case backgrounded processes stay alive on terminal exit.  In non-interactive scenarios, background processes stay in the same pgroup as the shell, which can be managed as, well, a group.
 - If built with `JOB_PROTECT`, then _es_ attempts to put itself in the foreground after each `wait()`. This is to avoid accidentally getting stopped by the `SIGT*` signals, which usually ends up taking down the whole terminal.
 - If built with `JOB_PROTECT`, then _es_ "returns" the terminal to its previous foreground process group on exit, if relevant.  This is to avoid the case where an _es_ invoked by a non-pgroup-aware parent process causes that parent to be stopped by a `SIGT*` signal, which also usually takes down the whole terminal.

This is all in the vague direction of job control, but the intent is only to achieve the following three goals: 1. don't remove features that already exist (`$&newpgrp` and background processes in separate pgroups), 2. do so in a standards-compliant way (that is, using `setpgid` to actually create new process groups), and 3. maintain "sanity" (as in, don't kill terminals at surprising times) by default.  There's a little more complex behavior in this PR than I'd like, but I also think it's the minimal set of behavior to achieve these three things.

The overall high-level impact of this change is that forked processes will be stopped and killed more than they were before.  I think the new cases of stoppage and killage are more "correct", since the rest of the OS "expects" a process group/session structure like this in how it interacts with shells.  Some users may be disturbed that certain background processes exit at different times than they used to, however.  There should be no meaningful change for the `-DJOB_PROTECT=0` case.

Alternatives to the design proposed here include:
 - Using the `$&newpgrp` primitive, and maybe a new `$&newsession` primitive, to manage how backgrounding works, instead of compile-time flags.  Doing this with `$&newpgrp` is like half-way to my job control proposal (#84) so I hesitate to suggest that here, though.  And I don't have a good idea whether a `$&newsession` primitive is really very useful -- maybe the few users who really want new sessions can use the `setsid` binary?
 - Maintaining "sanity" through primitives in the shell rather than within the C runtime.  Personally, I think of terminal process group management in the same category as automatically reaping processes that have been `wait()`ed for, or managing opening/closing file descriptors -- it's almost certainly better to just let the shell runtime do it.