### PR TITLE
Use local definitions for (get put set unset)^env, if possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,22 +66,22 @@ AC_FUNC_MMAP
 AC_CHECK_FUNCS(strerror strtol lstat setrlimit sigrelse sighold sigaction \
 sysconf setsid sigsetjmp getrusage)
 
-AC_CACHE_CHECK(for an abused getenv, es_cv_abused_getenv,
+AC_CACHE_CHECK(whether getenv can be redefined, es_cv_replaceable_getenv,
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
-changequote(,)
-char *foo = 0;
-char *foov[] = { "-a", "-bfoo", "bar" };
-int fooc = (sizeof(foov) / sizeof(foov[0]));
+#include <stdlib.h>
+static char *sentinel = "a value";
 
-int getenv() { return *foo; }
-int main() { while (-1 != getopt(fooc, foov, "ab:")); exit(0); }
-changequote([,])
-]])],[es_cv_abused_getenv=no],[es_cv_abused_getenv=yes
-AC_DEFINE([ABUSED_GETENV], [1], [Is getenv called by crt*.o or getopt?])],[]))
+char *getenv(const char *name) { return sentinel; }
 
-if test "$es_cv_abused_getenv" = yes
+int main(int argc, char **argv) {
+	char *v = getenv("key");
+	return (v == sentinel) ? 0 : 1;
+}
+]])],[es_cv_replaceable_getenv=yes],[es_cv_replaceable_getenv=no]))
+
+if test "$es_cv_replaceable_getenv" = yes
 then
-	rm -f core conftest.core
+	AC_DEFINE(REPLACEABLE_GETENV, [1], [Can getenv() be replaced with a local definition?])
 fi
 
 dnl Check to see if you can assign to a va_list

--- a/es.h
+++ b/es.h
@@ -286,10 +286,8 @@ extern void sethistory(char *file);
 extern Boolean isinteractive(void);
 #if HAVE_READLINE
 extern void setmaxhistorylength(int length);
-#if ABUSED_GETENV
+#endif
 extern void initgetenv(void);
-#endif
-#endif
 extern void initinput(void);
 extern void resetparser(void);
 

--- a/input.c
+++ b/input.c
@@ -36,13 +36,14 @@ static int historyfd = -1;
 #include <readline/history.h>
 
 Boolean reloadhistory = FALSE;
+#endif
 
-#if ABUSED_GETENV
+#if REPLACEABLE_GETENV
 static char *stdgetenv(const char *);
 static char *esgetenv(const char *);
 static char *(*realgetenv)(const char *) = stdgetenv;
 #endif
-#endif
+
 
 
 /*
@@ -258,10 +259,10 @@ static char *callreadline(char *prompt0) {
 	SIGCHK();
 	return r;
 }
+#endif
 
-#if ABUSED_GETENV
-
-/* getenv -- fake version of getenv for readline (or other libraries) */
+#if REPLACEABLE_GETENV
+/* esgetenv -- fake version of getenv for readline (or other libraries) */
 static char *esgetenv(const char *name) {
 	List *value = varlookup(name, NULL);
 	if (value == NULL)
@@ -293,9 +294,7 @@ static char *esgetenv(const char *name) {
 	}
 }
 
-static char *
-stdgetenv(const char *name)
-{
+static char *stdgetenv(const char *name) {
 	extern char **environ;
 	register int len;
 	register const char *np;
@@ -313,21 +312,14 @@ stdgetenv(const char *name)
 	return (NULL);
 }
 
-char *
-getenv(const char *name)
-{
+char *getenv(const char *name) {
 	return realgetenv(name);
 }
 
-extern void
-initgetenv(void)
-{
+extern void initgetenv(void) {
 	realgetenv = esgetenv;
 }
-
-#endif /* ABUSED_GETENV */
-
-#endif	/* HAVE_READLINE */
+#endif
 
 /* fdfill -- fill input buffer by reading from a file descriptor */
 static int fdfill(Input *in) {

--- a/var.c
+++ b/var.c
@@ -455,11 +455,8 @@ extern int setenv(const char *name, const char *value, int overwrite) {
 		return -1;
 	}
 	Ref(char *, envname, str(ENV_DECODE, name));
-	if (!overwrite && varlookup(envname, NULL) != NULL) {
-		RefPop(envname);
-		return 0;
-	}
-	importvar(envname, (char *)value);
+	if (overwrite || varlookup(envname, NULL) == NULL)
+		importvar(envname, (char *)value);
 	RefEnd(envname);
 	return 0;
 }
@@ -469,7 +466,7 @@ extern int unsetenv(const char *name) {
 		errno = EINVAL;
 		return -1;
 	}
-	vardef(str(ENV_DECODE, name), NULL, NULL);
+	vardef0(str(ENV_DECODE, name), NULL, NULL, TRUE);
 	return 0;
 }
 

--- a/var.c
+++ b/var.c
@@ -26,7 +26,7 @@
 	} \
 )
 
-Dict *vars;
+Dict *vars = NULL;
 static Dict *noexport;
 static Vector *env, *sortenv;
 static int envmin;
@@ -450,6 +450,7 @@ static void importvar(char *name0, char *value) {
 
 #if REPLACEABLE_GETENV
 extern int setenv(const char *name, const char *value, int overwrite) {
+	assert(vars != NULL);
 	if (name == NULL || name[0] == '\0' || strchr(name, '=') != NULL) {
 		errno = EINVAL;
 		return -1;
@@ -462,6 +463,7 @@ extern int setenv(const char *name, const char *value, int overwrite) {
 }
 
 extern int unsetenv(const char *name) {
+	assert(vars != NULL);
 	if (name[0] == '\0' || strchr(name, '=') != NULL) {
 		errno = EINVAL;
 		return -1;
@@ -474,6 +476,7 @@ extern int putenv(char *envstr) {
 	size_t n = strcspn(envstr, "=");
 	char *envname;
 	int status;
+	assert(vars != NULL);
 	if (n == 0 || envstr[n] != '=') {
 		/* null variable name or missing '=' char */
 		errno = EINVAL;


### PR DESCRIPTION
Most of this is due to @memreflect (see #45).  All I've really done is added an autoconf `REPLACEABLE_GETENV` test to verify whether we can change these library functions.

Adding the other `*env` functions to the set that is redefined allows readline to read and write "environment variables" properly, so we get working `$LINES` and `$COLUMNS`.

We also _only_ gate the redefinition behind the `REPLACEABLE_GETENV` test, regardless of any other conditions like if readline is linked in or if getopt calls getenv.  As memreflect found, the abused getenv test was buggy, and I think in general it's better to have and not to need.

A potential limitation -- the clever `stdgetenv`/`esgetenv` swap-out is not duplicated for the other functions, which just blindly assert that `initvars()` has already been called.  This seems to not break anything right now, but if more general external-library linking is added (or if there's a libc that depends on this somewhere) it'll need to change.

A side note - calls to these `*env` functions do not cause settor invocation.  Doing so would be problematic for _es_' GC'd memory, because it would be calling into _es_ code while untracked memory references are potentially live in the parser and/or libraries.  Conveniently, we just added code for "vardef but don't call settors", so it works out.