### PR TITLE
Small nitpicks caught by valgrind.

### DIFF
--- a/prim-io.c
+++ b/prim-io.c
@@ -204,7 +204,7 @@ PRIM(pipe) {
 
 	for (;; list = list->next) {
 		int p[2], pid;
-		
+
 		pid = (list->next == NULL) ? efork(TRUE, FALSE) : pipefork(p, &inpipe);
 
 		if (pid == 0) {		/* child */
@@ -222,7 +222,8 @@ PRIM(pipe) {
 			exit(exitstatus(eval1(list->term, evalflags | eval_inchild)));
 		}
 		pids[n++] = pid;
-		close(inpipe);
+		if (inpipe != -1)
+			close(inpipe);
 		if (list->next == NULL)
 			break;
 		list = list->next->next;

--- a/proc.c
+++ b/proc.c
@@ -43,7 +43,11 @@ extern int efork(Boolean parent, Boolean background) {
 			return pid;
 		}
 		case 0:		/* child */
-			proclist = NULL;
+			while (proclist != NULL) {
+				Proc *p = proclist;
+				proclist = proclist->next;
+				efree(p);
+			}
 			hasforked = TRUE;
 			break;
 		case -1:


### PR DESCRIPTION
Don't attempt to close an fd we know is invalid; also bother to `free()` the proclist on a fork.

Neither of these are fixes for any real issues.