### PR TITLE
Don't depend on $ac_cv_header_stdc being available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,10 +67,10 @@ AC_CHECK_FUNCS(strerror strtol lstat setrlimit sigrelse sighold sigaction \
 sysconf sigsetjmp getrusage)
 
 AC_CACHE_CHECK(whether getenv can be redefined, es_cv_local_getenv,
-[if test "$ac_cv_header_stdc" = no; then
+[if test "$ac_cv_header_stdlib_h" = no || test "$ac_cv_header_stdc" = no; then
 	es_cv_local_getenv=yes
 fi
-if test "$ac_cv_header_stdc" = yes; then
+if test "$ac_cv_header_stdlib_h" = yes || test "$ac_cv_header_stdc" = yes; then
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 static char *sentinel = "a value";


### PR DESCRIPTION
@memreflect (reasonably) suggested using `$ac_cv_header_stdc` to verify whether the `AC_HEADERS_STDC` check passed.  That's consistent with the autoconf 2.67 documentation.  However, it seems that since autoconf 2.70 (based on docs) and certainly in autoconf 2.72 (based on testing), that cache variable no longer gets defined.  If I create a minimal configure.ac
```
AC_INIT
AC_HEADER_STDC
```
and build and run `./configure` using autoconf 2.72, then `config.log` includes the following cache variables:
```
ac_cv_c_compiler_gnu=yes
ac_cv_env_CC_set=
ac_cv_env_CC_value=
ac_cv_env_CFLAGS_set=
ac_cv_env_CFLAGS_value=
ac_cv_env_CPPFLAGS_set=
ac_cv_env_CPPFLAGS_value=
ac_cv_env_LDFLAGS_set=
ac_cv_env_LDFLAGS_value=
ac_cv_env_LIBS_set=
ac_cv_env_LIBS_value=
ac_cv_env_build_alias_set=
ac_cv_env_build_alias_value=
ac_cv_env_host_alias_set=
ac_cv_env_host_alias_value=
ac_cv_env_target_alias_set=
ac_cv_env_target_alias_value=
ac_cv_header_inttypes_h=yes
ac_cv_header_stdint_h=yes
ac_cv_header_stdio_h=yes
ac_cv_header_stdlib_h=yes
ac_cv_header_string_h=yes
ac_cv_header_strings_h=yes
ac_cv_header_sys_stat_h=yes
ac_cv_header_sys_types_h=yes
ac_cv_header_unistd_h=yes
ac_cv_objext=o
ac_cv_path_EGREP='/usr/bin/grep -E'
ac_cv_path_EGREP_TRADITIONAL='/usr/bin/grep -E'
ac_cv_path_GREP=/usr/bin/grep
ac_cv_prog_ac_ct_CC=gcc
ac_cv_prog_cc_c11=
ac_cv_prog_cc_g=yes
ac_cv_prog_cc_stdc=
```
Note that in particular `ac_cv_header_stdc` is missing, but `ac_cv_header_stdlib_h` is present.

I'm not 100% confident the current behavior is correct in all cases, but I'm also 90% sure it doesn't matter at all, because I don't think anyone's building _es_ on systems that lack the standard C89 libraries these days.