### PR TITLE
Add a few things to make `$&wait`ing more flexible.

### DIFF
--- a/doc/es.1
+++ b/doc/es.1
@@ -1856,7 +1856,7 @@ as input to
 and executes its contents.
 The options are a subset of the invocation options for the shell (see below).
 .TP
-.Cr "access \fR[\fP-n \fIname\fP\fR]\fP \fR[\fP-1e\fR]\fP \fR[\fP-rwx\fR]\fP  \fR[\fP-fdcblsp\fR]\fP \fIpath ...\fP"
+.Cr "access \fR[\fP-n \fIname\fP\fR]\fP \fR[\fP-1e\fR]\fP \fR[\fP-rwx\fR]\fP \fR[\fP-fdcblsp\fR]\fP \fIpath ...\fP"
 Tests if the named paths are accessible according to the options presented.
 Normally,
 .Cr access
@@ -2192,7 +2192,7 @@ are specified,
 .Cr \-e
 is used.
 .TP
-.Cr "wait \fI\fR[\fPpid\fR]"
+.Cr "wait \fR[\fP-n\fR]\fP \fI\fR[\fPpid\fR]"
 Waits for the specified
 .IR pid ,
 which must have been started by
@@ -2200,6 +2200,11 @@ which must have been started by
 If no
 .I pid
 is specified, waits for any child process to exit.
+If
+.Cr \-n
+is specified and the process(es) to be waited for is (are) not ready
+at call time, returns immediately instead of blocking or throwing an
+error.
 .TP
 .Cr "whatis \fIprogram ...\fP"
 For each named
@@ -2292,6 +2297,19 @@ copied (via
 .IR dup (2))
 to file descriptor
 .IR newfd .
+.TP
+.Cr "%echo-status \fIpid did status\fP"
+Inspects the exit
+.I status
+of an exited (and waited-for) process
+.IR pid ,
+where
+.I did
+indicates if the process
+.Cr exited
+or was
+.Cr signaled ,
+and prints any interesting condition.
 .TP
 .Cr "%eval-noprint \fIcmd\fP"
 Run the command.
@@ -2740,7 +2758,7 @@ variable, which signals to the
 library how much of the history file should be read into the in-memory
 history log.
 .PP
-Several primitives are not directly associated with other function.
+Several primitives are not directly associated with other functions.
 They are:
 .TP
 .Cr "$&collect"
@@ -2750,7 +2768,7 @@ The garbage collector in
 runs rather frequently;
 there should be no reason for a user to issue this command.
 .TP
-.Cr "$&noreturn \fIlambda args ...\fP"
+.Cr "$&noreturn \fIlambda args ..."
 Call the
 .IR lambda ,
 but in such a way that it does not catch the
@@ -2764,6 +2782,11 @@ operations in
 and
 .Cr "&&" )
 can be implemented as lambdas rather than primitives.
+.TP
+.Cr "$&sigmessage"
+converts a signal name such as
+.Cr sigint
+to a short message describing the signal, used for error reporting.
 .TP
 .Cr "$&primitives"
 Returns a list of the names of es primitives.

--- a/es.h
+++ b/es.h
@@ -226,8 +226,8 @@ extern int efork(Boolean parent, Boolean background);
 extern pid_t spgrp(pid_t pgid);
 extern int tctakepgrp(void);
 extern void initpgrp(void);
-extern int ewait(int pid, Boolean interruptible, void *rusage);
-#define	ewaitfor(pid)	ewait(pid, FALSE, NULL)
+extern int ewait(int pid, int opts, void *rusage);
+#define	ewaitfor(pid)	ewait(pid, 0, NULL)
 
 #if JOB_PROTECT
 extern void tcreturnpgrp(void);

--- a/es.h
+++ b/es.h
@@ -222,7 +222,7 @@ extern char *checkexecutable(char *file);
 /* proc.c */
 
 extern Boolean hasforked;
-extern int efork(Boolean parent, Boolean background);
+extern int efork(Boolean parent);
 extern pid_t spgrp(pid_t pgid);
 extern int tctakepgrp(void);
 extern void initpgrp(void);

--- a/eval.c
+++ b/eval.c
@@ -41,7 +41,7 @@ extern List *forkexec(char *file, List *list, Boolean inchild) {
 		sigint_newline = TRUE;
 	} else
 		SIGCHK();
-	printstatus(0, status);
+	printstatus(pid, status);
 	return mklist(mkterm(mkstatus(status), NULL), NULL);
 }
 

--- a/eval.c
+++ b/eval.c
@@ -28,7 +28,7 @@ extern List *forkexec(char *file, List *list, Boolean inchild) {
 	Vector *env;
 	gcdisable();
 	env = mkenv();
-	pid = efork(!inchild, FALSE);
+	pid = efork(!inchild);
 	if (pid == 0) {
 		execve(file, vectorize(list)->vector, env->vector);
 		failexec(file, list);
@@ -41,7 +41,6 @@ extern List *forkexec(char *file, List *list, Boolean inchild) {
 		sigint_newline = TRUE;
 	} else
 		SIGCHK();
-	printstatus(pid, status);
 	return mklist(mkterm(mkstatus(status), NULL), NULL);
 }
 

--- a/initial.es
+++ b/initial.es
@@ -582,7 +582,7 @@ if {~ <=$&primitives execfailure} {fn-%exec-failure = $&execfailure}
 #	status from an exec()ed binary.
 
 fn %print-status pid did status {
-	if {~ $did signaled} {
+	if {~ $did signaled && !~ $status (sigint sigpipe)} {
 		let (msg = <={if {$print-status-pid} {result $pid^': '} {result ''}}) {
 			msg = $msg^<={$&sigmessage $status}
 			if {~ $status *+core} {

--- a/initial.es
+++ b/initial.es
@@ -661,7 +661,7 @@ fn %interactive-loop {
 				$fn-%dispatch false
 			} {~ $e signal} {
 				if {!~ $type sigint sigterm sigquit} {
-					echo >[1=2] caught unexpected signal: $type
+					echo >[1=2] caught unexpected signal: $type: <={$&sigmessage $type}
 				}
 			} {
 				echo >[1=2] uncaught exception: $e $type $msg

--- a/initial.es
+++ b/initial.es
@@ -578,12 +578,12 @@ fn %pathsearch name { access -n $name -1e -xf $path }
 
 if {~ <=$&primitives execfailure} {fn-%exec-failure = $&execfailure}
 
-#	The %print-status hook is used to print any potentially interesting
+#	The %echo-status hook is used to print any potentially interesting
 #	status from an exec()ed binary.
 
-fn %print-status pid did status {
+fn %echo-status pid did status {
 	if {~ $did signaled && !~ $status (sigint sigpipe)} {
-		let (msg = <={if {$print-status-pid} {result $pid^': '} {result ''}}) {
+		let (msg = <={if {$echo-status-pid} {result $pid^': '} {result ''}}) {
 			msg = $msg^<={$&sigmessage $status}
 			if {~ $status *+core} {
 				msg = $msg^'--core dumped'
@@ -593,10 +593,10 @@ fn %print-status pid did status {
 	}
 }
 
-print-status-pid = false
+echo-status-pid = false
 
 fn wait {
-	local (print-status-pid = true) $&wait $*
+	local (echo-status-pid = true) $&wait $*
 }
 
 #

--- a/initial.es
+++ b/initial.es
@@ -76,7 +76,6 @@ fn-newpgrp	= $&newpgrp
 fn-result	= $&result
 fn-throw	= $&throw
 fn-umask	= $&umask
-fn-wait		= $&wait
 
 fn-%read	= $&read
 
@@ -579,6 +578,26 @@ fn %pathsearch name { access -n $name -1e -xf $path }
 
 if {~ <=$&primitives execfailure} {fn-%exec-failure = $&execfailure}
 
+#	The %print-status hook is used to print any potentially interesting
+#	status from an exec()ed binary.
+
+fn %print-status pid did status {
+	if {~ $did signaled} {
+		let (msg = <={if {$print-status-pid} {result $pid^': '} {result ''}}) {
+			msg = $msg^<={$&sigmessage $status}
+			if {~ $status *+core} {
+				msg = $msg^'--core dumped'
+			}
+			echo >[1=2] $msg
+		}
+	}
+}
+
+print-status-pid = false
+
+fn wait {
+	local (print-status-pid = true) $&wait $*
+}
 
 #
 # Read-eval-print loops
@@ -756,7 +775,7 @@ max-eval-depth	= 640
 #	is does.  fn-%dispatch is really only important to the current
 #	interpreter loop.
 
-noexport = noexport pid signals apid bqstatus fn-%dispatch path home matchexpr
+noexport = noexport pid signals apid bqstatus fn-%dispatch path home matchexpr print-status-pid
 
 
 #

--- a/mksignal
+++ b/mksignal
@@ -34,12 +34,14 @@ sed -n '
 		mesg["SIGHUP"]		= "hangup"
 		mesg["SIGILL"]		= "illegal instruction"
 		mesg["SIGINFO"]		= "information request"
+		mesg["SIGINT"]		= "interrupt"
 		mesg["SIGIO"]		= "input/output possible"
 		mesg["SIGIOT"]		= "IOT instruction"
 		mesg["SIGKILL"]		= "killed"
 		mesg["SIGLOST"]		= "resource lost"
 		mesg["SIGLWP"]		= "lightweight process library signal"
 		mesg["SIGMIGRATE"]	= "migrate process"
+		mesg["SIGPIPE"]		= "broken pipe"
 		mesg["SIGPOLL"]		= "pollable event occurred"
 		mesg["SIGPROF"]		= "profiling timer alarm"
 		mesg["SIGPWR"]		= "power failure"
@@ -82,13 +84,6 @@ sed -n '
 		mesg["SIGVIRT"]		= "virtual time alarm"
 		mesg["SIGWINDOW"]	= "window size changed"
 
-
-		# set nomesg["SIGNAME"] to suppress message printing
-
-		nomesg["SIGINT"] = 1
-		nomesg["SIGPIPE"] = 1
-
-
 		# set ignore["SIGNAME"] to explicitly ignore a named signal (usually, this
 		# is just for things that look like signals but really are not)
 
@@ -117,7 +112,7 @@ sed -n '
 	sig[$1] == 0 && ignore[$1] == 0 {
 		sig[$1] = ++nsig
 		signame[nsig] = $1
-		if (mesg[$1] == "" && nomesg[$1] == 0) {
+		if (mesg[$1] == "") {
 			str = $3
 			for (i = 4; i <= NF; i++)
 				str = str " " $i

--- a/prim-io.c
+++ b/prim-io.c
@@ -234,9 +234,10 @@ PRIM(pipe) {
 
 	Ref(List *, result, NULL);
 	do {
+		int pid = pids[--n];
 		Term *t;
-		int status = ewaitfor(pids[--n]);
-		printstatus(0, status);
+		int status = ewaitfor(pid);
+		printstatus(pid, status);
 		t = mkstr(mkstatus(status));
 		result = mklist(t, result);
 	} while (0 < n);
@@ -280,7 +281,7 @@ PRIM(readfrom) {
 
 	close(p[0]);
 	status = ewaitfor(pid);
-	printstatus(0, status);
+	printstatus(pid, status);
 	varpop(&push);
 	RefEnd3(cmd, input, var);
 	RefReturn(lp);
@@ -320,7 +321,7 @@ PRIM(writeto) {
 
 	close(p[1]);
 	status = ewaitfor(pid);
-	printstatus(0, status);
+	printstatus(pid, status);
 	varpop(&push);
 	RefEnd3(cmd, output, var);
 	RefReturn(lp);
@@ -365,11 +366,11 @@ PRIM(backquote) {
 	}
 
 	close(p[1]);
-	gcdisable();
 	lp = bqinput(sep, p[0]);
 	close(p[0]);
 	status = ewaitfor(pid);
-	printstatus(0, status);
+	printstatus(pid, status);
+	gcdisable();
 	lp = mklist(mkstr(mkstatus(status)), lp);
 	gcenable();
 	list = lp;

--- a/prim-sys.c
+++ b/prim-sys.c
@@ -36,7 +36,7 @@ PRIM(newpgrp) {
 }
 
 PRIM(background) {
-	int pid = efork(TRUE, TRUE);
+	int pid = efork(TRUE);
 	if (pid == 0) {
 #if JOB_PROTECT
 		/* job control safe version: put it in a new pgroup, if interactive. */
@@ -51,12 +51,11 @@ PRIM(background) {
 
 PRIM(fork) {
 	int pid, status;
-	pid = efork(TRUE, FALSE);
+	pid = efork(TRUE);
 	if (pid == 0)
 		esexit(exitstatus(eval(list, NULL, evalflags | eval_inchild)));
 	status = ewaitfor(pid);
 	SIGCHK();
-	printstatus(pid, status);
 	return mklist(mkstr(mkstatus(status)), NULL);
 }
 
@@ -320,13 +319,12 @@ PRIM(time) {
 
 	gc();	/* do a garbage collection first to ensure reproducible results */
 	t0 = time(NULL);
-	pid = efork(TRUE, FALSE);
+	pid = efork(TRUE);
 	if (pid == 0)
 		esexit(exitstatus(eval(lp, NULL, evalflags | eval_inchild)));
 	status = ewait(pid, 0, &r);
 	t1 = time(NULL);
 	SIGCHK();
-	printstatus(pid, status);
 
 	eprint(
 		"%6ldr %5ld.%ldu %5ld.%lds\t%L\n",
@@ -345,7 +343,7 @@ PRIM(time) {
 	Ref(List *, lp, list);
 
 	gc();	/* do a garbage collection first to ensure reproducible results */
-	pid = efork(TRUE, FALSE);
+	pid = efork(TRUE);
 	if (pid == 0) {
 		clock_t t0, t1;
 		struct tms tms;
@@ -355,14 +353,13 @@ PRIM(time) {
 			ticks = sysconf(_SC_CLK_TCK);
 
 		t0 = times(&tms);
-		pid = efork(TRUE, FALSE);
+		pid = efork(TRUE);
 		if (pid == 0)
 			esexit(exitstatus(eval(lp, NULL, evalflags | eval_inchild)));
 
 		status = ewaitfor(pid);
 		t1 = times(&tms);
 		SIGCHK();
-		printstatus(pid, status);
 
 		tms.tms_cutime += ticks / 20;
 		tms.tms_cstime += ticks / 20;
@@ -378,7 +375,6 @@ PRIM(time) {
 	}
 	status = ewaitfor(pid);
 	SIGCHK();
-	printstatus(pid, status);
 
 	RefEnd(lp);
 	return mklist(mkstr(mkstatus(status)), NULL);

--- a/prim-sys.c
+++ b/prim-sys.c
@@ -323,7 +323,7 @@ PRIM(time) {
 	pid = efork(TRUE, FALSE);
 	if (pid == 0)
 		esexit(exitstatus(eval(lp, NULL, evalflags | eval_inchild)));
-	status = ewait(pid, FALSE, &r);
+	status = ewait(pid, 0, &r);
 	t1 = time(NULL);
 	SIGCHK();
 	printstatus(pid, status);

--- a/status.c
+++ b/status.c
@@ -65,7 +65,7 @@ extern char *mkstatus(int status) {
 
 /* printstatus -- print the status if we should */
 extern void printstatus(int pid, int status) {
-	Ref(List *, fn, varlookup("fn-%print-status", NULL));
+	Ref(List *, fn, varlookup("fn-%echo-status", NULL));
 	Ref(List *, list, NULL);
 	if (fn != NULL) {
 		gcdisable();

--- a/status.c
+++ b/status.c
@@ -65,18 +65,15 @@ extern char *mkstatus(int status) {
 
 /* printstatus -- print the status if we should */
 extern void printstatus(int pid, int status) {
-	if (WIFSIGNALED(status)) {
-		const char *msg = sigmessage(WTERMSIG(status)), *tail = "";
-		if (WCOREDUMP(status)) {
-			tail = "--core dumped";
-			if (*msg == '\0')
-				tail += (sizeof "--") - 1;
-		}
-		if (*msg != '\0' || *tail != '\0') {
-			if (pid == 0)
-				eprint("%s%s\n", msg, tail);
-			else
-				eprint("%d: %s%s\n", pid, msg, tail);
-		}
+	Ref(List *, fn, varlookup("fn-%print-status", NULL));
+	Ref(List *, list, NULL);
+	if (fn != NULL) {
+		gcdisable();
+		list = mklist(mkstr(mkstatus(status)), NULL);
+		list = mklist(mkstr((WIFSIGNALED(status) ? "signaled" : "exited")), list);
+		list = mklist(mkstr(str("%d", pid)), list);
+		gcenable();
+		eval(append(fn, list), NULL, 0);
 	}
+	RefEnd2(list, fn);
 }


### PR DESCRIPTION
This PR adds a few things:

First, an `-n` flag for `wait`, which corresponds with `waitpid(WNOHANG)`.  This can be used to implement a `check-wait` function during `%prompt`, something some shells do automatically.

To support that use case, there is a new hook function `%echo-status`, which is called when any process is `ewait()`ed for, and performs the work of printing the "interesting" signal terminations.  A default implementation is provided which should be the same as the current behavior. A quick-and-dirty way to hack on this function is to simply set `fn-%echo-status = echo` to see how every process exits:
```
; fn-%echo-status = echo
; cat /usr/share/dict/words | head -5 | wc -c
18
32920 exited 0
32919 exited 0
32918 signaled sigpipe
```
To make a backwards-compatible `%echo-status` possible, this PR also adds a new `$&sigmessage` primitive which externalizes the `sigmessage()` function.  This seems generally useful for signal exception handlers as well; the `%interactive-loop` function has been modified to use this primitive.
```
; echo $pid 
34157
; echo $signals 
.sigint /sigquit /sigterm sigpoll sigurg
; # here we run some kills in another terminal
; caught unexpected signal: sigpoll: pollable event occurred
; caught unexpected signal: sigurg: urgent condition on i/o channel
```
Putting these all together, the following enables the "check-wait" behavior on prompt like in other, job controlling shells:
```
fn check-wait {
  local (
    fn %echo-status pid did status {
      if {~ $did signaled} {
        echo >[1=2] $pid terminated on signal: <={$&sigmessage $status}
      } {
        echo >[1=2] $pid exited with status $status
      }
    }
  ) $&wait -n
}

let (p = $fn-%prompt)
fn %prompt {
  check-wait
  $p
}
```