### PR TITLE
Fixes for recently-introduced readline and `$&time` bugs

### DIFF
--- a/es.h
+++ b/es.h
@@ -226,8 +226,8 @@ extern int efork(Boolean parent, Boolean background);
 extern pid_t spgrp(pid_t pgid);
 extern int tctakepgrp(void);
 extern void initpgrp(void);
-extern int ewait(int pid, Boolean interruptible, void *rusage);
-#define	ewaitfor(pid)	ewait(pid, FALSE, NULL)
+extern int ewait(int pid, Boolean interruptible);
+#define	ewaitfor(pid)	ewait(pid, FALSE)
 
 #if JOB_PROTECT
 extern void tcreturnpgrp(void);

--- a/input.c
+++ b/input.c
@@ -245,6 +245,8 @@ static char *callreadline(char *prompt0) {
 		rl_reset_terminal(NULL);
 		resetterminal = FALSE;
 	}
+	if (RL_ISSTATE(RL_STATE_INITIALIZED))
+		rl_reset_screen_size();
 	interrupted = FALSE;
 	if (!setjmp(slowlabel)) {
 		slow = TRUE;

--- a/prim-sys.c
+++ b/prim-sys.c
@@ -311,9 +311,7 @@ PRIM(time) {
 
 	Ref(List *, lp, list);
 
-	if (getrusage(RUSAGE_CHILDREN, &ru_prev) == -1)
-		fail("es:ewait", "getrusage: %s", esstrerror(errno));
-
+	getrusage(RUSAGE_CHILDREN, &ru_prev);
 	gc();	/* do a garbage collection first to ensure reproducible results */
 	t0 = time(NULL);
 	pid = efork(TRUE, FALSE);
@@ -324,9 +322,7 @@ PRIM(time) {
 	SIGCHK();
 	printstatus(0, status);
 
-	if (getrusage(RUSAGE_CHILDREN, &ru_new) == -1)
-		fail("es:ewait", "getrusage: %s", esstrerror(errno));
-
+	getrusage(RUSAGE_CHILDREN, &ru_new);
 	timesub(&ru_new.ru_utime, &ru_prev.ru_utime, &ru_diff.ru_utime);
 	timesub(&ru_new.ru_stime, &ru_prev.ru_stime, &ru_diff.ru_stime);
 

--- a/proc.c
+++ b/proc.c
@@ -2,13 +2,6 @@
 
 #include "es.h"
 
-/* TODO: the rusage code for the time builtin really needs to be cleaned up */
-
-#if HAVE_GETRUSAGE
-#include <sys/time.h>
-#include <sys/resource.h>
-#endif
-
 Boolean hasforked = FALSE;
 
 typedef struct Proc Proc;
@@ -123,26 +116,9 @@ extern Noreturn esexit(int code) {
 }
 #endif
 
-#if HAVE_GETRUSAGE
-/* This function is provided as timersub(3) on some systems, but it's simple enough
- * to do ourselves. */
-static void timesub(struct timeval *a, struct timeval *b, struct timeval *res) {
-	res->tv_sec = a->tv_sec - b->tv_sec;
-	res->tv_usec = a->tv_usec - b->tv_usec;
-	if (res->tv_usec < 0) {
-		res->tv_sec -= 1;
-		res->tv_usec += 1000000;
-	}
-}
-#endif
-
-/* dowait -- a waitpid wrapper that gets rusage and interfaces with signals */
-static int dowait(int pid, int *statusp, void UNUSED *rusagep) {
+/* dowait -- a waitpid wrapper that interfaces with signals */
+static int dowait(int pid, int *statusp) {
 	int n;
-#if HAVE_GETRUSAGE
-	static struct rusage ru_saved;
-	struct rusage ru_new;
-#endif
 	interrupted = FALSE;
 	if (!setjmp(slowlabel)) {
 		slow = TRUE;
@@ -151,16 +127,6 @@ static int dowait(int pid, int *statusp, void UNUSED *rusagep) {
 	} else
 		n = -2;
 	slow = FALSE;
-#if HAVE_GETRUSAGE
-	if (getrusage(RUSAGE_CHILDREN, &ru_new) == -1)
-		fail("es:ewait", "getrusage: %s", esstrerror(errno));
-	if (rusagep != NULL) {
-		struct rusage *rusage = (struct rusage *)rusagep;
-		timesub(&ru_new.ru_utime, &ru_saved.ru_utime, &rusage->ru_utime);
-		timesub(&ru_new.ru_stime, &ru_saved.ru_stime, &rusage->ru_stime);
-	}
-	ru_saved = ru_new;
-#endif
 	if (n == -2) {
 		errno = EINTR;
 		n = -1;
@@ -185,10 +151,10 @@ static Proc *reap(int pid) {
 }
 
 /* ewait -- wait for a specific process to die, or any process if pid == -1 */
-extern int ewait(int pidarg, Boolean interruptible, void *rusage) {
+extern int ewait(int pidarg, Boolean interruptible) {
 	int deadpid, status;
 	Proc *proc;
-	while ((deadpid = dowait(pidarg, &status, rusage)) == -1) {
+	while ((deadpid = dowait(pidarg, &status)) == -1) {
 		if (errno == ECHILD && pidarg > 0)
 			fail("es:ewait", "wait: %d is not a child of this shell", pidarg);
 		else if (errno != EINTR)
@@ -234,7 +200,7 @@ PRIM(wait) {
 		fail("$&wait", "usage: wait [pid]");
 		NOTREACHED;
 	}
-	return mklist(mkstr(mkstatus(ewait(pid, TRUE, NULL))), NULL);
+	return mklist(mkstr(mkstatus(ewait(pid, TRUE))), NULL);
 }
 
 extern Dict *initprims_proc(Dict *primdict) {

--- a/proc.c
+++ b/proc.c
@@ -148,19 +148,19 @@ static int dowait(int pid, int *statusp, void UNUSED *rusagep) {
 		slow = TRUE;
 		n = interrupted ? -2 :
 			waitpid(pid, statusp, 0);
-#if HAVE_GETRUSAGE
-		if (rusagep != NULL) {
-			struct rusage *rusage = (struct rusage *)rusagep;
-			if (getrusage(RUSAGE_CHILDREN, &ru_new) == -1)
-				fail("es:ewait", "getrusage: %s", esstrerror(errno));
-			timesub(&ru_new.ru_utime, &ru_saved.ru_utime, &rusage->ru_utime);
-			timesub(&ru_new.ru_stime, &ru_saved.ru_stime, &rusage->ru_stime);
-			ru_saved = ru_new;
-		}
-#endif
 	} else
 		n = -2;
 	slow = FALSE;
+#if HAVE_GETRUSAGE
+	if (getrusage(RUSAGE_CHILDREN, &ru_new) == -1)
+		fail("es:ewait", "getrusage: %s", esstrerror(errno));
+	if (rusagep != NULL) {
+		struct rusage *rusage = (struct rusage *)rusagep;
+		timesub(&ru_new.ru_utime, &ru_saved.ru_utime, &rusage->ru_utime);
+		timesub(&ru_new.ru_stime, &ru_saved.ru_stime, &rusage->ru_stime);
+	}
+	ru_saved = ru_new;
+#endif
 	if (n == -2) {
 		errno = EINTR;
 		n = -1;


### PR DESCRIPTION
Fixes #151 (introduced with #128) and #152 (introduced with #143).

`getrusage()` has been pulled out of `proc.c` entirely and is now managed within `$&time`.  I think this structure is a lot better in terms of separation-of-concerns.  It's also nicely simple to implement with how `getrusage()` works, which is something that seemed very weird to me at first.  So that's nice!

It occurs to me with this change that if we make use of `getrusage(RUSAGE_SELF)` as well, we could actually `$&time` commands without forking, which seems like an interesting possibility.  If you have a slow-running script, you could just wrap whole sections inside a `time {}` without any disruption to the script's function...  Even better, it looks like the standard `times()` also supports getting times from the calling process, so we could keep things consistent. (Edit: This is now #154)

We don't do anything so clever with `rl_reset_screen_size()`, even though it's easy to imagine something that waits for a `SIGWINCH` and only calls resets the screen size then.  However, that requires a novel kind of special signal handling for `SIGWINCH`, and `SIGWINCH` isn't even technically POSIX.1-2001 standard, so we'd have to wrap a fair amount inside of `#ifdef SIGWINCH`, and this is all adding a fair amount of complexity for a very negligible performance/efficiency gain.