### PR TITLE
Nitpicky changes to man page

### DIFF
--- a/doc/es.1
+++ b/doc/es.1
@@ -251,27 +251,27 @@ gives several characters special meaning;
 special characters automatically terminate words.
 The following characters, along with space, tab, and newline, are special:
 .Ds
-.Cr "# $ & \' ( ) ; < = > \e ^ \` { | }"
+.Cr "# $ & \(aq ( ) ; < = > \e \(ha \(ga { | }"
 .De
 .PP
 The single quote
-.Rc ( ' )
+.Rc ( \(aq )
 prevents special treatment of any character other than itself.
 Any characters between single quotes, including newlines, backslashes,
 and control characters, are treated as an uninterpreted string.
 A quote character itself may be quoted by placing two quotes in a row.
 A single quote character is therefore represented by the sequence
-.Cr '''' .
+.Cr \(aq\(aq\(aq\(aq .
 The empty string is represented by
-.Cr '' .
+.Cr \(aq\(aq .
 Thus:
 .Ds
-.Cr "echo 'What''s the plan, Stan?'"
+.Cr "echo \(aqWhat\(aq\(aqs the plan, Stan?\(aq"
 .De
 .PP
 prints out
 .Ds
-.Cr "What's the plan, Stan?"
+.Cr "What\(aqs the plan, Stan?"
 .De
 .PP
 The backslash
@@ -344,7 +344,7 @@ Thus, the following are all equivalent:
 .De
 .PP
 Note that the null string,
-.Cr "''" ,
+.Cr "\(aq\(aq" ,
 and the empty list,
 .Cr "()" ,
 are two very
@@ -353,10 +353,10 @@ Assigning the null string to variable is a valid
 operation, but it does not remove its definition.
 .SS Concatenation
 Two lists may be joined by the concatenation operator
-.Rc ( ^ ).
+.Rc ( \(ha ).
 A single word is a list of length one, so
 .Ds
-.Cr "echo foo^bar"
+.Cr "echo foo\(habar"
 .De
 .PP
 produces the output
@@ -368,7 +368,7 @@ For lists of more than one element,
 concatenation produces the cross (Cartesian) product of
 the elements in both lists:
 .Ds
-.Cr "echo (a\- b\- c\-)^(1 2)"
+.Cr "echo (a\- b\- c\-)\(ha(1 2)"
 .De
 .PP
 produces the output
@@ -464,7 +464,7 @@ To reference a variable with other
 characters in its name, quote the variable name.
 Thus:
 .Ds
-.Cr "echo $'we$Ird\Variab!le'"
+.Cr "echo $\(aqwe$Ird\Variab!le\(aq"
 .De
 .PP
 A variable name produced by some complex operation,
@@ -478,7 +478,7 @@ Thus:
 .Cr "Good\-Morning = Bonjour"
 .Cr "Guten = Good"
 .Cr "Morgen = Morning"
-.Cr "echo $($Guten^\-^$Morgen)"
+.Cr "echo $($Guten\(ha\-\(ha$Morgen)"
 .De
 .PP
 prints
@@ -544,7 +544,7 @@ prints
 .De
 .PP
 Subscript ranges are of the form
-.Ic lo ... hi
+.Ic lo " ... " hi
 and refer to all the elements between
 .I lo
 and
@@ -587,7 +587,7 @@ Note that the list of subscripts may be given by any
 .IR es
 expression, so
 .Ds
-.Cr "$var(\`{awk 'BEGIN{for(i=1;i<=10;i++)print i;exit }'})"
+.Cr "$var(\(ga{awk \(aqBEGIN{for(i=1;i<=10;i++)print i;exit }\(aq})"
 .De
 .PP
 returns the first 10 elements of
@@ -599,7 +599,7 @@ in order to save some typing on the user's behalf.
 For example, the following are all equivalent:
 .Ds
 .Cr "cc \-O \-g \-c malloc.c alloca.c"
-.Cr "cc \-^(O g c) (malloc alloca)^.c"
+.Cr "cc \-\(ha(O g c) (malloc alloca)\(ha.c"
 .Cr "opts=O g c; files=malloc alloca; cc \-$opts $files.c"
 .De
 .PP
@@ -623,7 +623,7 @@ inserts a caret between them.
 To create a single-element list from a multi-element list,
 with the components space-separated, use
 .Ds
-.Ci $^ var
+.Ci $\(ha var
 .De
 .PP
 Flattening is useful when the normal list concatenation rules need to be
@@ -632,18 +632,9 @@ For example, to append a single period at the end of
 .Cr $path ,
 use:
 .Ds
-.Cr "echo $^path"
+.Cr "echo $\(hapath."
 .De
 .PP
-To flatten the output of a command, use
-.Ds
-.Ci \`^{ "cmd args" }
-.De
-.PP
-See the section entitled
-.B "Command Substitution"
-for more information.
-
 .SS "Wildcard Expansion"
 .I Es
 expands wildcards in filenames if possible.
@@ -662,7 +653,7 @@ will only perform pattern matching if a metacharacter occurs unquoted and
 literally in the input.
 Thus,
 .Ds
-.Cr "foo = '*'"
+.Cr "foo = \(aq*\(aq"
 .Cr "echo $foo"
 .De
 .PP
@@ -690,7 +681,7 @@ with the exception that character class negation is achieved
 with the tilde
 .Rc ( ~ ),
 not the caret
-.Rc ( ^ ),
+.Rc ( \(ha ),
 since the caret already means
 something else in
 .IR es .
@@ -814,7 +805,7 @@ exist:
 .Cr "    \fIpattern1\fP	{\fIaction1\fP}"
 .Cr "    (\fIpattern2 pattern3\fP)	{\fIaction2\fP}"
 .Cr "    * {"
-.Cr "        throw error example no matching patterns"
+.Cr "        echo no matching patterns"
 .Cr "    }"
 .Cr ")"
 .De
@@ -894,7 +885,7 @@ is the list
 A list may be formed from the output of a command by using backquote
 substitution:
 .Ds
-.Ci "\`{" " command " }
+.Ci "\(ga{" " command " }
 .De
 .PP
 returns a list formed from the standard output of the command in braces.
@@ -910,9 +901,9 @@ By default,
 has the value space-tab-newline.
 The braces may be omitted if the command is a single word.
 Thus
-.Cr \`ls
+.Cr \(gals
 may be used instead of
-.Cr "\`{ls}" .
+.Cr "\(ga{ls}" .
 This last feature is useful when defining functions that expand
 to useful argument lists.
 A frequent use is:
@@ -922,7 +913,7 @@ A frequent use is:
 .PP
 followed by
 .Ds
-.Cr "wc \`src"
+.Cr "wc \(gasrc"
 .De
 .PP
 (This will print out a word-count of all C and Yacc source files in the current
@@ -932,7 +923,7 @@ In order to override the value of
 .Cr $ifs
 for a single command substitution, use:
 .Ds
-.Ci "\`\`" " ifs-list " { " command " }
+.Ci "\(ga\(ga" " ifs-list " { " command " }
 .De
 .PP
 .Cr $ifs
@@ -940,7 +931,7 @@ will be temporarily ignored and the command's output will be split as specified 
 the list following the double backquote.
 For example:
 .Ds
-.Cr "\`\` :\en {cat /etc/passwd}"
+.Cr "\(ga\(ga :\en {cat /etc/passwd}"
 .De
 .PP
 splits up
@@ -948,9 +939,20 @@ splits up
 into fields.
 .PP
 A caret
-.Rc ( ^ )
+.Rc ( \(ha )
 can be added after the backquote to flatten the list output back into a single
-element (using space as the separator).
+element (using space as the separator) as follows:
+.Ds
+.Ci "\(ga\(ha{" " command " "}"
+.De
+.PP
+Or, to flatten the output of a command substitution but still specify
+.Cr ifs ,
+this can be used:
+.Ds
+.Ci "\(ga\(ga\(ha" " ifs " "{" " command " "}"
+.De
+.PP
 .SS "Return Values"
 The return value of a command is obtained with the construct
 .Ds
@@ -1066,21 +1068,19 @@ these operators use file descriptor 1 by default.
 .IR sh (1)
 with the use of
 .Ds
-.Ic command " << '" eof-marker "'"
+.Ic command " << \(aq" eof-marker "\(aq"
 .De
 .PP
 If the end-of-file marker is quoted,
 then no variable substitution occurs inside the here document.
 Otherwise, every variable is substituted
-by its space-separated-list value (see
-.BR "Flat Lists" ,
-below),
+by its space-separated-list value
 and if a
-.Cr ^
+.Cr \(ha
 character follows a variable name, it is deleted.
 This allows the unambiguous use of variables adjacent to text, as in
 .Ds
-.Cr $variable^follow
+.Cr $variable\(hafollow
 .De
 .PP
 To include a literal
@@ -1094,7 +1094,7 @@ supports ``here strings'', which are like here documents,
 except that input is taken directly from a string on the command line.
 Its use is illustrated here:
 .Ds
-.Cr "cat <<< 'this is a here string' | wc"
+.Cr "cat <<< \(aqthis is a here string\(aq | wc"
 .De
 .PP
 (This feature enables
@@ -1126,8 +1126,9 @@ use:
 .Ic command " |[2] wc"
 .De
 .PP
-The exit status of a pipeline is considered true if and only if every
-command in the pipeline exits true.
+A pipeline returns a list containing each element's exit status, which
+means that the exit status of a pipeline is considered true if and
+only if every command in the pipeline exits true.
 .SS "Input/Output Substitution"
 Some commands, like
 .IR cmp (1)
@@ -1161,7 +1162,7 @@ Data can be sent down a pipe to several commands using
 .IR tee (1)
 and the output version of this notation:
 .Ds
-.Cr "echo hi there | tee >{sed 's/^/p1 /'} >{sed 's/^/p2 /'}"
+.Cr "echo hi there | tee >{sed \(aqs/\(ha/p1 /\(aq} >{sed \(aqs/\(ha/p2 /\(aq}"
 .De
 .SS "Program Fragments"
 .I Es
@@ -1526,7 +1527,7 @@ is the name of the routine (typically a primitive) which
 raised the error.
 .TP
 .Cr retry
-When raised from a signal catcher,
+When raised from an exception catcher,
 causes the body of the
 .Cr catch
 clause to be run again.
@@ -1629,6 +1630,35 @@ The initial value of
 .Cr ifs
 is space-tab-newline.
 .TP
+.Cr max-eval-depth
+Limits the maximum depth of the internal
+.I es
+call stack.
+If that maximum depth is reached, an error exception is thrown.
+This protects the shell (and the user) from crashes when unbounded
+recursion happens.
+If
+.Cr max-eval-depth
+is set to
+.Cr 0
+or the empty list, the limit is disabled.
+.TP
+.Cr max-history-length
+(If readline support is compiled in) limits the number of entries in
+readline's in-memory history.
+Reducing this value speeds up shell startup and certain other
+operations.
+If
+.Cr max-history-length
+is set to
+.Cr 0 ,
+then in-memory history is disabled (though if
+.Cr $history
+is set, lines will still be logged to the history file.)
+If
+.Cr max-history-length
+is set to the empty list, the length limit is removed.
+.TP
 .Cr noexport
 A list of variables which
 .I es
@@ -1652,11 +1682,13 @@ are set at startup time,
 .Cr path
 assumes a default value suitable for your system.
 This is typically
-.Cr "/usr/ucb /usr/bin /bin ''" .
+.Cr "/usr/ucb /usr/bin /bin \(aq\(aq" .
 .TP
 .Cr pid
 The process ID of the currently running
 .IR es .
+This value does not change in subshells started by constructs like
+.Cr fork .
 .TP
 .Cr prompt
 This variable holds the two prompts (in list form) that
@@ -1673,7 +1705,7 @@ for details.)
 sets
 .Cr $prompt
 to
-.Cr "('; ' '')"
+.Cr "(\(aq; \(aq \(aq\(aq)"
 by default.
 The reason for this is that it enables an
 .I es
@@ -1797,7 +1829,7 @@ rather than executing them.
 \fIcmd1\fP ; \fIcmd2\fP	%seq {\fIcmd1\fP} {\fIcmd2\fP}
 \fIcmd1\fP && \fIcmd2\fP	%and {\fIcmd1\fP} {\fIcmd2\fP}
 \fIcmd1\fP || \fIcmd2\fP	%or {\fIcmd1\fP} {\fIcmd2\fP}
-fn \fIname\fP \fIargs\fP { \fIcmd\fP }	fn-^\fIname\fP = @ \fIargs\fP {\fIcmd\fP}
+fn \fIname\fP \fIargs\fP { \fIcmd\fP }	fn-\(ha\fIname\fP = @ \fIargs\fP {\fIcmd\fP}
 .ft R
 .De
 .SS "Input/Output Commands"
@@ -1825,9 +1857,13 @@ fn \fIname\fP \fIargs\fP { \fIcmd\fP }	fn-^\fIname\fP = @ \fIargs\fP {\fIcmd\fP}
 .Ds
 .ft \*(Cf
 $#\fIvar\fP	<={%count $\fIvar\fP}
-$^\fIvar\fP	<={%flatten ' ' $\fIvar\fP}
-\`{\fIcmd args\fP}	<={%backquote <={%flatten '' $ifs} {\fIcmd args\fP}}
-\`\` \fIifs\fP {\fIcmd args\fP}	<={%backquote <={%flatten '' \fIifs\fP} {\fIcmd args\fP}}
+$\(ha\fIvar\fP	<={%flatten \(aq \(aq $\fIvar\fP}
+\(ga{\fIcmd args\fP}	<={%backquote <={%flatten \(aq\(aq $ifs} {\fIcmd args\fP}}
+\(ga\(ga \fIifs\fP {\fIcmd args\fP}	<={%backquote <={%flatten \(aq\(aq \fIifs\fP} {\fIcmd args\fP}}
+\(ga\(ha{\fIcmd args\fP}
+        <={%flatten \(aq \(aq <={%backquote <={%flatten \(aq\(aq $ifs} {\fIcmd args\fP}}}
+\(ga\(ga\(ha \fIifs\fP {\fIcmd args\fP}
+        <={%flatten \(aq \(aq <={%backquote <={%flatten \(aq\(aq \fIifs\fP} {\fIcmd args\fP}}}
 .ft R
 .De
 .SH BUILTINS
@@ -2260,7 +2296,7 @@ into elements according to
 .Cr %batch-loop
 Parses commands from the current input source and
 passes the commands to the function
-.IR %dispatch ,
+.Cr %dispatch ,
 which is usually a dynamically bound identifier.
 This function catches the exception
 .Cr eof
@@ -2295,20 +2331,17 @@ to file descriptor
 .TP
 .Cr "%eval-noprint \fIcmd\fP"
 Run the command.
-(Passed as the argument to
-.Cr %batch-loop
-and
-.Cr %interactive-loop .)
+Used as the value of
+.Cr %dispatch
+by default.
 .TP
 .Cr "%eval-print \fIcmd\fP"
 Print and run the command.
-(Passed as the argument to
-.Cr %batch-loop
-and
-.Cr %interactive-loop
+Used as the value of
+.Cr %dispatch
 when the
 .Cr \-x
-option is used.)
+option is used.
 .TP
 .Cr "%exec-failure \fIfile argv0 args ...\fP"
 This function, if it exists, is called in the context of a
@@ -2337,10 +2370,8 @@ shell scripts if the kernel does not.
 Runs the command, and exits if any command
 (except those executing as the tests of conditional statements)
 returns a non-zero status.
-(This function is used as an argument to
-.Cr %batch-loop
-and
-.Cr %interactive-loop
+(This function is used in the definition of
+.Cr %dispatch
 when the shell is invoked with the
 .Cr \-e
 option.)
@@ -2367,7 +2398,7 @@ if there are no arguments.
 Prompts,
 parses commands from the current input source and
 passes the commands to the function
-.IR %dispatch ,
+.Cr %dispatch ,
 which is usually a dynamically bound identifier.
 This function catches the exception
 .Cr eof
@@ -2380,25 +2411,21 @@ commands, when the input source is interactive.
 .TP
 .Cr "%noeval-noprint \fIcmd\fP"
 Do nothing.
-(Passed as the argument to
-.Cr %batch-loop
-and
-.Cr %interactive-loop
+Used as the value of
+.Cr %dispatch
 when the
 .Cr \-n
-option is used.)
+option is used.
 .TP
 .Cr "%noeval-print \fIcmd\fP"
 Print but don't run the command.
-(Passed as the argument to
-.Cr %batch-loop
-and
-.Cr %interactive-loop
+Used as the value of
+.Cr %dispatch
 when the
 .Cr \-x
 and
 .Cr \-n
-options are used.)
+options are used.
 .TP
 .Cr "%not \fIcmd\fP"
 Runs the command and returns false if its exit status was true,


### PR DESCRIPTION
- Use `\(ha`, `\(aq`, and `\(ga` to get correctly-rendered ^, ', and ` in all cases
- Fix "lo ... hi" to include spaces
- Add period to `$^path.` which I erroneously removed before
- Remove `throw` from the `match` command example, since exceptions haven't been explained at that point in the doc
- Move the flatten-backtick example from the variable-flattening to the command-substitution section
- Describe the return value of a pipeline more specifically
- Change "signal catcher" to "exception catcher"
- Add `max-eval-depth` and `max-history-length`
- Update `%eval-noprint` and friends to refer to `%dispatch` instead of being arguments to the REPL functions