### PR TITLE
Small fixes, mostly around return

### DIFF
--- a/initial.es
+++ b/initial.es
@@ -83,14 +83,14 @@ fn-%read	= $&read
 #	eval runs its arguments by turning them into a code fragment
 #	(in string form) and running that fragment.
 
-fn eval { '{' ^ $^* ^ '}' }
+fn-eval = $&noreturn @ { '{' ^ $^* ^ '}' }
 
 #	Through version 0.84 of es, true and false were primitives,
 #	but, as many pointed out, they don't need to be.  These
 #	values are not very clear, but unix demands them.
 
-fn-true		= result 0
-fn-false	= result 1
+fn-true		= { result 0 }
+fn-false	= { result 1 }
 
 #	These functions just generate exceptions for control-flow
 #	constructions.  The for command and the while builtin both
@@ -495,7 +495,7 @@ fn-%pipe	= $&pipe
 if {~ <=$&primitives readfrom} {
 	fn-%readfrom = $&readfrom
 } {
-	fn %readfrom var input cmd {
+	fn-%readfrom = $&noreturn @ var input cmd {
 		local ($var = /tmp/es.$var.$pid) {
 			unwind-protect {
 				$input > $$var
@@ -511,7 +511,7 @@ if {~ <=$&primitives readfrom} {
 if {~ <=$&primitives writeto} {
 	fn-%writeto = $&writeto
 } {
-	fn %writeto var output cmd {
+	fn-%writeto = $&noreturn @ var output cmd {
 		local ($var = /tmp/es.$var.$pid) {
 			unwind-protect {
 				> $$var
@@ -667,11 +667,11 @@ fn %interactive-loop {
 #	function.  (For %eval-noprint, note that an empty list prepended
 #	to a command just causes the command to be executed.)
 
-fn %eval-noprint				# <default>
-fn %eval-print		{ echo $* >[1=2]; $* }	# -x
-fn %noeval-noprint	{ }			# -n
-fn %noeval-print	{ echo $* >[1=2] }	# -n -x
-fn-%exit-on-false = $&exitonfalse		# -e
+fn-%eval-noprint	=					# <default>
+fn-%eval-print		= $&noreturn @ { echo $* >[1=2]; $* }	# -x
+fn-%noeval-noprint	= { }					# -n
+fn-%noeval-print	= @ { echo $* >[1=2] }			# -n -x
+fn-%exit-on-false	= $&exitonfalse				# -e
 
 
 #

--- a/share/status.es
+++ b/share/status.es
@@ -19,6 +19,15 @@ fn %interactive-loop {
 	local (
 		noexport = $noexport status
 		status = <=true
-		fn %dispatch {status = <={$d $*}}
+		fn-%dispatch = $&noreturn @ {
+			catch @ e rest {
+				if {~ $e return} {
+					status = $rest
+				}
+				throw $e $rest
+			} {
+				status = <={$d $*}
+			}
+		}
 	) $loop $*
 }


### PR DESCRIPTION
Fixes #145.

 - `eval` is noreturn, so `@ {eval return 1; return 2}` appropriately returns 1.
 - `%eval-print` is noreturn, so `es -xc 'return 99'` behaves like `es -c 'return 99'` does.
 - Non-primitive `%readfrom` and `%writeto` are noreturn, so `return <{true}` behaves consistently in both primitive and non-primitive forms.
 - `share/status.es` sets `$status` based on return exceptions, and keeps `%dispatch` noreturn.

Not so related to return: `true` and `false` don't include their arguments in their return value, such that `true blah` returns `0` instead of `0 blah`, which is falsey.