### PR TITLE
Small fixes/improvements to printed trees

### DIFF
--- a/conv.c
+++ b/conv.c
@@ -84,10 +84,18 @@ top:
 		tailcall(n->u[1].p, TRUE);
 
 	case nMatch:
+		if (n->u[1].p == NULL) {
+			fmtprint(f, "~ %#T", n->u[0].p);
+			return FALSE;
+		}
 		fmtprint(f, "~ %#T ", n->u[0].p);
 		tailcall(n->u[1].p, FALSE);
 
 	case nExtract:
+		if (n->u[1].p == NULL) {
+			fmtprint(f, "~~ %#T", n->u[0].p);
+			return FALSE;
+		}
 		fmtprint(f, "~~ %#T ", n->u[0].p);
 		tailcall(n->u[1].p, FALSE);
 
@@ -129,7 +137,9 @@ top:
 	case nVar:
 		fmtputc(f, '$');
 		n = n->u[0].p;
-		if (n == NULL || n->kind == nWord || n->kind == nQword)
+		if (n == NULL || n->kind == nList)
+			tailcall(n, TRUE);
+		else if (n->kind == nWord || n->kind == nQword)
 			goto top;
 		fmtprint(f, "(%#T)", n);
 		return FALSE;
@@ -137,7 +147,7 @@ top:
 	case nLambda:
 		fmtprint(f, "@ ");
 		if (n->u[0].p == NULL)
-			fmtprint(f, "* ");
+			fmtprint(f, "*");
 		else
 			fmtprint(f, "%T", n->u[0].p);
 		fmtprint(f, "{%T}", n->u[1].p);


### PR DESCRIPTION
```
; es.old -c 'echo {~ x ()}'
{~ x }
; es.new -c 'echo {~ x ()}'
{~ x}
```
```
; es.old -c 'echo @ {}; echo @ * {}'
@ * {}
@ *{}
; es.new -c 'echo @ {}; echo @ * {}'
@ *{}
@ *{}
```
```
; es.old -c 'echo {$(a b)}'
{$((a b))}
; es.new -c 'echo {$(a b)}'
{$(a b)}
```
```
; es.old -c 'echo {$()}'
{$}
; es.new -c 'echo {$()}'
{$()}
```
I don't love all these choices personally (I'd rather `{~ x ()}` than `{~ x}` and `@ * {}` rather than `@ *{}`), but concision is pretty valuable when stuffing these strings into the environment, so I won't fight too hard to add more characters than strictly necessary (Adding parens to `{$}` is necessary because `{$}` isn't actually valid syntax).