### PR TITLE
Include git commit information in $&version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ y.*
 initial.c
 sigmsgs.c
 token.h
+version.h
 es
 esdump
 testrun

--- a/Makefile.in
+++ b/Makefile.in
@@ -66,7 +66,7 @@ OFILES	= access.o closure.o conv.o dict.o eval.o except.o fd.o gc.o glob.o \
 	  sigmsgs.o signal.o split.o status.o str.o syntax.o term.o token.o \
 	  tree.o util.o var.o vec.o version.o y.tab.o
 OTHER	= Makefile parse.y mksignal
-GEN	= esdump y.tab.c y.tab.h y.output token.h sigmsgs.c initial.c
+GEN	= esdump y.tab.c y.tab.h y.output token.h version.h sigmsgs.c initial.c
 
 SIGFILES = @SIGFILES@
 
@@ -109,6 +109,9 @@ y.tab.c y.tab.h : parse.y
 token.h : y.tab.h
 	-cmp -s y.tab.h token.h || cp y.tab.h token.h
 
+version.h : mkversion .git/index
+	sh $(srcdir)/mkversion > version.h
+
 initial.c : esdump $(srcdir)/initial.es
 	./esdump < $(srcdir)/initial.es > initial.c
 
@@ -140,7 +143,7 @@ open.o : open.c es.h config.h stdenv.h
 opt.o : opt.c es.h config.h stdenv.h 
 prim.o : prim.c es.h config.h stdenv.h prim.h 
 prim-ctl.o : prim-ctl.c es.h config.h stdenv.h prim.h 
-prim-etc.o : prim-etc.c es.h config.h stdenv.h prim.h 
+prim-etc.o : prim-etc.c es.h config.h stdenv.h prim.h version.h
 prim-io.o : prim-io.c es.h config.h stdenv.h gc.h prim.h 
 prim-sys.o : prim-sys.c es.h config.h stdenv.h prim.h 
 print.o : print.c es.h config.h stdenv.h print.h 
@@ -156,4 +159,4 @@ tree.o : tree.c es.h config.h stdenv.h gc.h
 util.o : util.c es.h config.h stdenv.h 
 var.o : var.c es.h config.h stdenv.h gc.h var.h term.h 
 vec.o : vec.c es.h config.h stdenv.h gc.h 
-version.o : version.c es.h config.h stdenv.h 
+version.o : version.c es.h config.h stdenv.h version.h

--- a/es.h
+++ b/es.h
@@ -373,7 +373,7 @@ extern int opentty(void);
 
 /* version.c */
 
-extern const char * const version;
+extern const List * const version;
 
 
 /* gc.c -- see gc.h for more */

--- a/initial.es
+++ b/initial.es
@@ -767,4 +767,5 @@ noexport = noexport pid signals apid bqstatus fn-%dispatch path home matchexpr
 #	is printed in the header comment in initial.c;  nobody really
 #	wants to look at initial.c anyway.
 
-result es initial state built in `/bin/pwd on `/bin/date for <=$&version
+let ((version date) = <=$&version)
+	result es initial state generated from version $version from $date

--- a/mkversion
+++ b/mkversion
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+v=$(git describe --tags 2>/dev/null)
+d=$(git show --no-patch --format=%ci | cut -f1 -d' ')
+
+echo "#define VERSION \"$v\""
+echo "#define VERSION_DATE \"$d\""

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -4,6 +4,7 @@
 
 #include "es.h"
 #include "prim.h"
+#include "version.h"
 
 PRIM(result) {
 	return list;
@@ -33,7 +34,7 @@ PRIM(setnoexport) {
 }
 
 PRIM(version) {
-	return mklist(mkstr((char *) version), NULL);
+	return (List *)version;
 }
 
 PRIM(exec) {

--- a/version.c
+++ b/version.c
@@ -1,3 +1,10 @@
 #include "es.h"
-static const char id[] = "@(#)es version 0.9.2 2-Mar-2022";
-const char * const version = id + (sizeof "@(#)" - 1);
+#include "term.h"
+#include "version.h"
+
+static const Term
+	version_date_term = { VERSION_DATE, NULL },
+	version_term = { VERSION, NULL };
+static const List vdl = { (Term *) &version_date_term, NULL };
+static const List versionstruct = { (Term *) &version_term, (List *)&vdl };
+const List * const version = &versionstruct;


### PR DESCRIPTION
This is a relatively small change.
```
; ./es.old -c 'echo <=$&version'
es version 0.9.2 2-Mar-2022
; ./es.new -c 'echo <=$&version'
v0.9.2-248-gc7c3c42 2025-03-01
```
Version information is now generated automatically by the `mkversion` script which calls `git describe --tags` and `git show --format=%ci`.

Breaking it down to most atomic units of user-visible change:
1. Changes version format from `0.9.2` to `v0.9.2` (this is just based on how `git` output is formatted)
2. Changes date format from `2-Mar-2022` to `2022-03-02` (also just based on `git` output formatting)
3. Removes the `es version ` prefix
4. Splits the return value into two separate terms, one for version string and one for commit date
5. For an _es_ built from a non-tagged commit, changes the return value from `v0.9.2` to `v0.9.2-(number of commits since tag)-g(commit id)`.

As a last piece, this changes the last line of `initial.es` to use the new `$&version` and remove the calls to `date` and `pwd` which upset reproducible-build systems like Nix.

The main point of this PR is to add the commit info, so that `$&version` produces output more specific than today's "built sometime in the last 3 years".  I think the old setup made a lot more sense in the '90s style of development without version control, and I think this setup makes more sense now.  The other changes are basically just aesthetic.

Fixes #147.  This is semi-cribbed from the setup that _rc_ has, so I guess this is also related to #1.