### PR TITLE
Remove potential race from yacc file generation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -103,8 +103,10 @@ test	: es testrun $(testdir)/test.es
 src	:
 	@echo ${OTHER} ${CFILES} ${HFILES}
 
-y.tab.c y.tab.h : parse.y
+y.tab.h	: parse.y
 	${YACC} -vd $(srcdir)/parse.y
+
+y.tab.c	: y.tab.h
 
 token.h : y.tab.h
 	-cmp -s y.tab.h token.h || cp y.tab.h token.h


### PR DESCRIPTION
Fixes #89.  Tested in the following rather brute-force way:
```
; for (i = `{seq 1 100}) {make clean; make -j || throw error make failed to build on iteration $i}
```