### PR TITLE
Fix $&if to run "elses" like "thens", not "tests"

### DIFF
--- a/prim-ctl.c
+++ b/prim-ctl.c
@@ -15,11 +15,10 @@ PRIM(seq) {
 PRIM(if) {
 	Ref(List *, lp, list);
 	for (; lp != NULL; lp = lp->next) {
-		List *cond = eval1(lp->term, evalflags & (lp->next == NULL ? eval_inchild : 0));
-		lp = lp->next;
-		if (lp == NULL) {
-			RefPop(lp);
-			return cond;
+		List *cond = ltrue;
+		if (lp->next != NULL) {
+			cond = eval1(lp->term, 0);
+			lp = lp->next;
 		}
 		if (istrue(cond)) {
 			List *result = eval1(lp->term, evalflags);

--- a/test/tests/option.es
+++ b/test/tests/option.es
@@ -14,6 +14,9 @@ test 'es -e' {
 			'false'					false
 			'if {false} {true}'			true
 			'if {true} {false}'			false
+			'if {false; true} {true}'		true
+			'if {true} {false; true}'		false
+			'if {false} {true} {false; true}'	false
 			'{true; {true; {false; true}}}'		false
 
 			# assignments


### PR DESCRIPTION
Found while looking at #73; `if` "turns off" the exit-on-false behavior when running each `test`, but the current behavior has it also do so while running the `else` command, which seems pretty clearly wrong.
```
if {false} {
  command which will not run
} {
  commands that might
  be risky
  don''''t you want
  some -e protection here?
}
```
The fact that this has never been reported before is, along with the fact that the bodies of `while` loops run with `eval_exitonfalse` toggled off, is pretty compelling evidence to me that nobody ever uses `-e`...