### PR TITLE
Exit with signal status if a signal exception reaches the top level

### DIFF
--- a/es.h
+++ b/es.h
@@ -359,6 +359,7 @@ extern jmp_buf slowlabel;
 extern Boolean sigint_newline;
 extern void sigchk(void);
 extern Boolean issilentsignal(List *e);
+extern void exitonsignal(List *e);
 extern void setsigdefaults(void);
 extern void blocksignals(void);
 extern void unblocksignals(void);

--- a/main.c
+++ b/main.c
@@ -31,7 +31,7 @@ static void checkfd(int fd, OpenKind r) {
 static void initpath(void) {
 	int i;
 	static const char * const path[] = { INITIAL_PATH };
-	
+
 	Ref(List *, list, NULL);
 	for (i = arraysize(path); i-- > 0;) {
 		Term *t = mkstr((char *) path[i]);
@@ -56,11 +56,13 @@ static void runesrc(void) {
 		CatchException (e)
 			if (termeq(e->term, "exit"))
 				exit(exitstatus(e->next));
-			else if (termeq(e->term, "error"))
+			else if (termeq(e->term, "error")) {
 				eprint("%L\n",
 				       e->next == NULL ? NULL : e->next->next,
 				       " ");
-			else if (!issilentsignal(e))
+				return;
+			}
+			if (!issilentsignal(e))
 				eprint("uncaught exception: %L\n", e, " ");
 			return;
 		EndExceptionHandler
@@ -179,19 +181,19 @@ getopt_done:
 		initinput();
 		initprims();
 		initvars();
-	
+
 		runinitial();
-	
+
 		initpath();
 		initpid();
 		initsignals(runflags & run_interactive, allowquit);
 		initpgrp();
 		hidevariables();
 		initenv(environ, protected);
-	
+
 		if (loginshell)
 			runesrc();
-	
+
 		if (cmd == NULL && !cmd_stdin && argp != NULL) {
 			int fd;
 			char *file = getstr(argp->term);
@@ -206,7 +208,7 @@ getopt_done:
 			status = exitstatus(runfd(fd, file, runflags));
 			goto return_main;
 		}
-	
+
 		vardef("*", NULL, argp);
 		vardef("0", NULL, mklist(mkstr(argv[0]), NULL));
 		if (cmd != NULL)
@@ -219,11 +221,19 @@ getopt_done:
 		if (termeq(e->term, "exit")) {
 			status = exitstatus(e->next);
 			goto return_main;
-		} else if (termeq(e->term, "error"))
+		} else if (termeq(e->term, "error")) {
 			eprint("%L\n",
 			       e->next == NULL ? NULL : e->next->next,
 			       " ");
-		else if (!issilentsignal(e))
+			status = 1;
+			goto return_main;
+		} else {
+#if JOB_PROTECT
+			tcreturnpgrp();
+#endif
+			exitonsignal(e);
+		}
+		if (!issilentsignal(e))
 			eprint("uncaught exception: %L\n", e, " ");
 		status = 1;
 

--- a/test/tests/trip.es
+++ b/test/tests/trip.es
@@ -224,12 +224,9 @@ test 'equal sign in command arguments' {
 }
 
 test 'exit with signal codes' {
-	# TODO: these `& wait`s work around a race against
-	#   `wait: $pid is not a child of this shell'
-	# Possibly #7?
-	assert {~ <={$es -c 'signals = sigterm; kill -TERM $pid & wait' >[2] /dev/null} sigterm} \
+	assert {~ <={$es -c 'signals = sigterm; kill -TERM $pid' >[2] /dev/null} sigterm} \
 		'die with a signal code'
-	assert {~ <={$es -c 'signals = sigchld; kill -CHLD $pid & wait' >[2] /dev/null} 1} \
+	assert {~ <={$es -c 'signals = sigchld; kill -CHLD $pid' >[2] /dev/null} 1} \
 		'die normally with an ignored signal'
 	assert {~ <={$es -c 'signals = -sigterm; throw signal sigterm' >[2] /dev/null} sigterm} \
 		'die from a thrown signal even if we would ignore it externally'

--- a/test/tests/trip.es
+++ b/test/tests/trip.es
@@ -214,7 +214,6 @@ test 'flat command expansion' {
 	assert {~ `` \n {$es -c '`^^{true}' >[2=1]} *'syntax error'*}
 }
 
-# Redundant with tests/embedded-eq.es
 test 'equal sign in command arguments' {
 	assert {$es -c 'echo foo=bar' > /dev/null} '''='' in argument does not cause error'
 	assert {~ `^{echo foo=bar} 'foo=bar'} '''='' is automatically concatenated with adjacent strings'
@@ -222,4 +221,16 @@ test 'equal sign in command arguments' {
 	assert {~ `^{echo foo = bar} 'foo = bar'} '''='' is not automatically concatenated with non-adjacent strings'
 	assert {~ `` \n {$es -c 'foo^= = 384; echo $foo'} *'= 384'*}
 	assert {~ `` \n {$es -c 'echo =foo; echo $echo'} *'foo'*}
+}
+
+test 'exit with signal codes' {
+	# TODO: these `& wait`s work around a race against
+	#   `wait: $pid is not a child of this shell'
+	# Possibly #7?
+	assert {~ <={$es -c 'signals = sigterm; kill -TERM $pid & wait' >[2] /dev/null} sigterm} \
+		'die with a signal code'
+	assert {~ <={$es -c 'signals = sigchld; kill -CHLD $pid & wait' >[2] /dev/null} 1} \
+		'die normally with an ignored signal'
+	assert {~ <={$es -c 'signals = -sigterm; throw signal sigterm' >[2] /dev/null} sigterm} \
+		'die from a thrown signal even if we would ignore it externally'
 }


### PR DESCRIPTION
With this PR, if a `signal sigfoo` exception is not caught, it causes the shell to die with a `sigfoo`, if the signal can do that.  This resolves the following inconsistency:
```
; echo <={es.old -c 'kill -term $pid'}
terminated
sigterm
; echo <={es.old -c 'signals = sigterm; kill -term $pid'}
uncaught exception: signal sigterm
1
```
See:
```
; echo <={es.new -c 'kill -term $pid'}
terminated
sigterm
; echo <={es.new -c 'signals = sigterm; kill -term $pid'}
terminated
sigterm
```
This does not change in which cases a signal causes a shell to exit, just the exit status of the shell in those cases where it does.  Fixes #112.

This PR revealed to me (but didn't cause) a couple small bugs with signal handling that I'd like to address separately:
1. The command `kill -$SIG $pid` in a shell that is configured to trigger an exception on a `$SIG` sometimes causes the shell to complain `wait: $pid is not a child of this shell` (with the actual pid in place of the variable, of course).  This might be the same as #7, or very related to it.
2. There is some inconsistency in the sigint newline:
```
; es -c 'signals = sigint; %read'
^C; es -c '%read'
^C
;
```