### PR TITLE
Small changes to printed trees -- take 2

### DIFF
--- a/conv.c
+++ b/conv.c
@@ -84,10 +84,18 @@ top:
 		tailcall(n->u[1].p, TRUE);
 
 	case nMatch:
+		if (n->u[1].p == NULL) {
+			fmtprint(f, "~ %#T", n->u[0].p);
+			return FALSE;
+		}
 		fmtprint(f, "~ %#T ", n->u[0].p);
 		tailcall(n->u[1].p, FALSE);
 
 	case nExtract:
+		if (n->u[1].p == NULL) {
+			fmtprint(f, "~~ %#T", n->u[0].p);
+			return FALSE;
+		}
 		fmtprint(f, "~~ %#T ", n->u[0].p);
 		tailcall(n->u[1].p, FALSE);
 
@@ -129,7 +137,9 @@ top:
 	case nVar:
 		fmtputc(f, '$');
 		n = n->u[0].p;
-		if (n == NULL || n->kind == nWord || n->kind == nQword)
+		if (n == NULL || n->kind == nList)
+			tailcall(n, TRUE);
+		else if (n->kind == nWord || n->kind == nQword)
 			goto top;
 		fmtprint(f, "(%#T)", n);
 		return FALSE;
@@ -137,7 +147,7 @@ top:
 	case nLambda:
 		fmtprint(f, "@ ");
 		if (n->u[0].p == NULL)
-			fmtprint(f, "* ");
+			fmtprint(f, "*");
 		else
 			fmtprint(f, "%T", n->u[0].p);
 		fmtprint(f, "{%T}", n->u[1].p);

--- a/test/tests/syntax.es
+++ b/test/tests/syntax.es
@@ -76,3 +76,15 @@ test 'match sugar' {
 		assert {~ `` \n {eval echo '{'$have'}'} '{'$want'}'}
 	}
 }
+
+test 'odd var formatting' {
+	for (syntax = (
+		'$()'
+		'$foo'
+		'$(foo bar)'
+		'$(foo^$bar)'
+		'$(<={foo})'
+	)) {
+		assert {~ `` \n {eval echo '{'$syntax'}'} '{'^$syntax^'}'}
+	}
+}


### PR DESCRIPTION
Small changes.
```
; es.old -c 'echo {@ {}} {@ * {}}'
{@ * {}} {@ *{}}
; es.new -c 'echo {@ {}} {@ * {}}'
{@ *{}} {@ *{}}
; es.old -c 'echo {~ a ()}'
{~ a }
; es.new -c 'echo {~ a ()}'
{~ a}
; es.old -c 'echo {$()}'
{$}
; es.new -c 'echo {$()}'
{$()}
; es.old -c 'echo {$(a)}'
{$(a)}
; es.new -c 'echo {$(a)}'
{$a}
; es.old -c 'echo {$(a b)}'
{$((a b))}
; es.new -c 'echo {$(a b)}'
{$(a b)}
; es.old -c 'echo {$(a b)}'
{$((a b))}
; es.new -c 'echo {$(a b)}'
{$(a b)}
```
Also add some test cases this time to avoid the kinds of regressions introduced in #162.  Most of these changes are for aesthetics and also serve to shorten the output (good for strings in the environment). The `{$()}` case is simply a bug fix.