### PR TITLE
Move LOCAL_GETENV handling to var.c where the other env handling lives.

### DIFF
--- a/es.h
+++ b/es.h
@@ -294,7 +294,6 @@ extern Tree *parse(char *esprompt1, char *esprompt2);
 extern Tree *parsestring(const char *str);
 extern Boolean isinteractive(void);
 extern Boolean isfromfd(void);
-extern void initgetenv(void);
 extern void initinput(void);
 extern void resetparser(void);
 

--- a/input.c
+++ b/input.c
@@ -1,5 +1,4 @@
 /* input.c -- read input from files or strings ($Revision: 1.2 $) */
-/* stdgetenv is based on the FreeBSD getenv */
 
 #include "es.h"
 #include "input.h"
@@ -31,13 +30,6 @@ Boolean resetterminal = FALSE;
 #if HAVE_READLINE
 #include <readline/readline.h>
 #endif
-
-#if LOCAL_GETENV
-static char *stdgetenv(const char *);
-static char *esgetenv(const char *);
-static char *(*realgetenv)(const char *) = stdgetenv;
-#endif
-
 
 
 /*
@@ -174,65 +166,6 @@ static char *callreadline(char *prompt0) {
 }
 #endif
 
-#if LOCAL_GETENV
-/* esgetenv -- fake version of getenv for readline (or other libraries) */
-static char *esgetenv(const char *name) {
-	List *value = varlookup(name, NULL);
-	if (value == NULL)
-		return NULL;
-	else {
-		char *export;
-		static Dict *envdict;
-		static Boolean initialized = FALSE;
-		Ref(char *, string, NULL);
-
-		gcdisable();
-		if (!initialized) {
-			initialized = TRUE;
-			envdict = mkdict();
-			globalroot(&envdict);
-		}
-
-		string = dictget(envdict, name);
-		if (string != NULL)
-			efree(string);
-
-		export = str("%W", value);
-		string = ealloc(strlen(export) + 1);
-		strcpy(string, export);
-		envdict = dictput(envdict, (char *) name, string);
-
-		gcenable();
-		RefReturn(string);
-	}
-}
-
-static char *stdgetenv(const char *name) {
-	extern char **environ;
-	register int len;
-	register const char *np;
-	register char **p, *c;
-
-	if (name == NULL || environ == NULL)
-		return (NULL);
-	for (np = name; *np && *np != '='; ++np)
-		continue;
-	len = np - name;
-	for (p = environ; (c = *p) != NULL; ++p)
-		if (strncmp(c, name, len) == 0 && c[len] == '=') {
-			return (c + len + 1);
-		}
-	return (NULL);
-}
-
-char *getenv(const char *name) {
-	return realgetenv(name);
-}
-
-extern void initgetenv(void) {
-	realgetenv = esgetenv;
-}
-#endif
 
 /* fdfill -- fill input buffer by reading from a file descriptor */
 static int fdfill(Input *in) {

--- a/var.c
+++ b/var.c
@@ -1,4 +1,5 @@
 /* var.c -- es variables ($Revision: 1.1.1.1 $) */
+/* stdgetenv is based on the FreeBSD getenv */
 
 #include "es.h"
 #include "gc.h"
@@ -392,9 +393,6 @@ extern void initvars(void) {
 	vars = mkdict();
 	noexport = NULL;
 	env = mkvector(ENVSIZE);
-#if LOCAL_GETENV
-	initgetenv();
-#endif
 }
 
 /* importvar -- import a single environment variable */
@@ -451,6 +449,64 @@ static void importvar(char *name0, char *value) {
 }
 
 #if LOCAL_GETENV
+static char *stdgetenv(const char *);
+static char *esgetenv(const char *);
+static char *(*realgetenv)(const char *) = stdgetenv;
+
+/* esgetenv -- fake version of getenv for readline (or other libraries) */
+static char *esgetenv(const char *name) {
+	List *value = varlookup(name, NULL);
+	if (value == NULL)
+		return NULL;
+	else {
+		char *export;
+		static Dict *envdict;
+		static Boolean initialized = FALSE;
+		Ref(char *, string, NULL);
+
+		gcdisable();
+		if (!initialized) {
+			initialized = TRUE;
+			envdict = mkdict();
+			globalroot(&envdict);
+		}
+
+		string = dictget(envdict, name);
+		if (string != NULL)
+			efree(string);
+
+		export = str("%W", value);
+		string = ealloc(strlen(export) + 1);
+		strcpy(string, export);
+		envdict = dictput(envdict, (char *) name, string);
+
+		gcenable();
+		RefReturn(string);
+	}
+}
+
+static char *stdgetenv(const char *name) {
+	extern char **environ;
+	register int len;
+	register const char *np;
+	register char **p, *c;
+
+	if (name == NULL || environ == NULL)
+		return (NULL);
+	for (np = name; *np && *np != '='; ++np)
+		continue;
+	len = np - name;
+	for (p = environ; (c = *p) != NULL; ++p)
+		if (strncmp(c, name, len) == 0 && c[len] == '=') {
+			return (c + len + 1);
+		}
+	return (NULL);
+}
+
+char *getenv(const char *name) {
+	return realgetenv(name);
+}
+
 extern int setenv(const char *name, const char *value, int overwrite) {
 	assert(vars != NULL);
 	if (name == NULL || name[0] == '\0' || strchr(name, '=') != NULL) {
@@ -536,4 +592,8 @@ extern void initenv(char **envp, Boolean protected) {
 	RefEnd2(var, imported);
 	envmin = env->count;
 	efree(buf);
+
+#if LOCAL_GETENV
+	realgetenv = esgetenv;
+#endif
 }


### PR DESCRIPTION
No user impact, pure code reorganization.  This is a piece of #178.  The location of `LOCAL_GETENV` in input.c is because it supports readline, but ideally we should move away from readline being "the library that _es_ uses" and toward "_es_ supports using different libraries according to what users want."