### PR TITLE
Handle EOF in scanerror instead of infinite-looping

### DIFF
--- a/test/tests/trip.es
+++ b/test/tests/trip.es
@@ -77,13 +77,13 @@ test 'umask' {
 		umask 0
 		> $tmp
 		let (x = `{ls -l $tmp})
-			assert {~ $x(1) '-rw-rw-rw-'} umask 0 produces correct result
+			assert {~ $x(1) '-rw-rw-rw-'*} umask 0 produces correct result
 
 		rm -f $tmp
 		umask 027
 		> $tmp
 		let (y = `{ls -l $tmp})
-			assert {~ $y(1) '-rw-r-----'} umask 027 produces correct file
+			assert {~ $y(1) '-rw-r-----'*} umask 027 produces correct file
 
 		assert {~ `umask 027 0027} fail umask reports correct value
 	} {

--- a/token.c
+++ b/token.c
@@ -77,7 +77,7 @@ extern void print_prompt2(void) {
 }
 
 /* scanerror -- called for lexical errors */
-static void scanerror(char c, char *s) {
+static void scanerror(int c, char *s) {
 	while (c != '\n' && c != EOF)
 		c = GETC();
 	goterror = TRUE;


### PR DESCRIPTION
It would be nice if we could have this (both signed and unsigned chars) checked automatically, but the only way I can think of to do that would get into a "build and test with multiple sets of CFLAGS", which is more than I'd want to get into at the moment.  I'm a little surprised there isn't some GCC or Clang warning that caught this for us.  `-Wconversion` does, but enabling that opens a much larger can of worms in another way.

This change also allows for extra characters at the end of permissions strings in `trip.es`.  Helps address the majority of #187, I believe, aside from `cat` behaving weird, which I don't think is an _es_ issue.