### PR TITLE
Remove SIGCHK() from eread() and ewrite().

### DIFF
--- a/prim-io.c
+++ b/prim-io.c
@@ -363,9 +363,9 @@ static List *bqinput(const char *sep, int fd) {
 	startsplit(sep, TRUE);
 
 restart:
+	/* avoid SIGCHK()ing in here so we don't abandon our child process */
 	while ((n = eread(fd, in, sizeof in)) > 0)
 		splitstring(in, n, FALSE);
-	SIGCHK();
 	if (n == -1) {
 		if (errno == EINTR)
 			goto restart;
@@ -377,7 +377,7 @@ restart:
 
 PRIM(backquote) {
 	int pid, p[2], status;
-	
+
 	caller = "$&backquote";
 	if (list == NULL)
 		fail(caller, "usage: backquote separator command [args ...]");

--- a/util.c
+++ b/util.c
@@ -110,7 +110,6 @@ extern void ewrite(int fd, const char *buf, size_t n) {
 		slow = FALSE;
 	}
 	slow = FALSE;
-	SIGCHK();
 }
 
 extern long eread(int fd, char *buf, size_t n) {
@@ -129,6 +128,5 @@ extern long eread(int fd, char *buf, size_t n) {
 		errno = EINTR;
 		r = -1;
 	}
-	SIGCHK();
 	return r;
 }


### PR DESCRIPTION
The callers of these functions are already doing their own `SIGCHK()`s as appropriate, and in certain cases we want to do these calls without `SIGCHK()`ing.

Fixes the following issue:
```
# from an es-at-HEAD REPL
; echo `{es -c 'signals = -sigint; echo <=%read'}
^C
;
```
Now that terminal is all messed up because the `es -c` process is still running and trying to read from it.
```
# from an es-at-this-fork REPL
; echo `{./es -c 'signals = -sigint; echo <=%read'}
^C^C^C^C^C^Cblah

; 
```
The parent _es_ no longer "abandons" its child, the child gets reaped when it actually exits, and everything stays reasonable.

You may note that the `blah` read by the child isn't actually echoed by the parent.  That seems to happen when a sigint is sent.  This seems to happen in every shell's equivalent of the ``echo `{}`` syntax though (and I tested with a bash script as the child too, in case it's an _es_ problem on that side), so it seems ubiquitous, so I'm not going to be too worried about it.

Found while looking into #187.  Unfortunately I don't have a good idea how to arrange the above issue from within a non-interactive script (without having it block forever), so it's not clear to me how to write a test case for it.