### PR TITLE
Fix string handling bug in putenv()

### DIFF
--- a/var.c
+++ b/var.c
@@ -540,8 +540,9 @@ extern int putenv(char *envstr) {
 		errno = EINVAL;
 		return -1;
 	}
-	envname = ealloc(n);
+	envname = ealloc(n+1);
 	memcpy(envname, envstr, n);
+	envname[n] = '\0';
 	status = setenv(envname, envstr + n + 1, 1);
 	efree(envname);
 	return status;


### PR DESCRIPTION
GNU Readline 4.3 on stock OpenBSD 7.6 uses `putenv()`, but the allocated string `envname` in `putenv()` was not properly null-terminated, leading to readline trying to set incorrect environment variable names like `LINES{garbage bytes}`.