### PR TITLE
Make the char *s involved in yyerror const

### DIFF
--- a/input.c
+++ b/input.c
@@ -37,16 +37,16 @@ Boolean resetterminal = FALSE;
  */
 
 /* locate -- identify where an error came from */
-static char *locate(Input *in, char *s) {
+static const char *locate(Input *in, const char *s) {
 	return (in->runflags & run_interactive)
 		? s
 		: str("%s:%d: %s", in->name, in->lineno, s);
 }
 
-static char *error = NULL;
+static const char *error = NULL;
 
 /* yyerror -- yacc error entry point */
-extern void yyerror(char *s) {
+extern void yyerror(const char *s) {
 #if sgi
 	/* this is so that trip.es works */
 	if (streq(s, "Syntax error"))
@@ -246,7 +246,7 @@ extern Tree *parse(char *pr1, char *pr2) {
 	gcenable();
 
 	if (result || error != NULL) {
-		char *e;
+		const char *e;
 		assert(error != NULL);
 		e = error;
 		error = NULL;

--- a/input.h
+++ b/input.h
@@ -28,7 +28,7 @@ struct Input {
 extern Input *input;
 extern void unget(Input *in, int c);
 extern Boolean ignoreeof;
-extern void yyerror(char *s);
+extern void yyerror(const char *s);
 
 
 /* token.c */


### PR DESCRIPTION
When bison is run with `POSIXLY_CORRECT`, it errors out if `yyerror` doesn't take a `const char *`.  Technically I believe it's right -- according to POSIX, this parameter should be `const`.