### PR TITLE
Update INSTALL instructions and add OpenBSD to them

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,9 +1,9 @@
 Basic Installation
 ------------------
 
-   Es now uses the GNU configure system for configuration.  This
-means that on nearly all platforms, it should just build and work
-fine.  To do this, just type:
+   Es uses the GNU configure system for configuration.  This means that
+on nearly all platforms, it should just build and work fine.  To do
+this, just type:
 
    % ./configure
    % make
@@ -22,7 +22,7 @@ we ask libtoolize to do the work.
    Es needs an ANSI compiler (or at least a compiler that respects
 protoypes and provides large portions of the ANSI library).
 Otherwise it should build with the basic tools available on most UNIX
-platforms.
+platforms.  Es expects a POSIX.1-2001 compliant OS and C library.
 
    Es obeys the GNU configure convention of allowing you to build in
 a directory different from the source directory.  To do this, just
@@ -41,23 +41,34 @@ library ($prefix/share by default).  These are given to configure by:
    % ./configure --prefix=directory
    % ./configure --bindir=directory --mandir=directory
 
-   Similarly, setting the `CC', `CFLAGS', and `LDFLAGS' environmental
+   Similarly, setting the `CC', `CFLAGS', and `LDFLAGS' environment
 variables will cause those to be used in the Makefile.
 
 Es Options
 ----------
 
-  Es can be built to link to two command line editing libraries:
-GNU readline and editline.  For information about obtaining these, see
-the README file.  These may used by providing, respectively, the
---with-readline or --with-editline respectively.  Readline is currently
-enabled by deafult.
+   Es can be built to link with GNU readline.  Readline may be used by
+providing the --with-readline flag to ./configure.  By default, readline
+is enabled if autoconf is able to find a working readline present on the
+system; to manually disable it, ./configure --without-readline.
 
 Problems with building
 ----------------------
 
-  The HP-UX yacc program seems to dislike the use of LOCAL in
-parse.y.  It is not clear to me why this is the case.  FSF's bison works
-fine.  This has not been `fixed' because it is not clear what is
-`broken'.  This may also be other dependencies that I do not
-understand.
+   OpenBSD requires some additional hoop-jumping to build from source.
+A recently successful installation required the following commands
+before ./configure.  Note that your locally installed autotool versions
+may differ.
+
+   % libtoolize -qi
+   % AUTOMAKE_VERSION=1.16 AUTOCONF_VERSION=2.71 autoreconf
+
+   In addition, OpenBSD has, by default, a very old version of readline
+installed, with which ./configure will detect and attempt to link.  To
+use the more up-to-date readline library available, the following is
+required:
+
+   % doas pkg_add readline  # your exact command may differ
+   % ./configure --with-readline \
+        READLINE_CFLAGS=-I/usr/local/include/ereadline \
+        READLINE_LIBS='-L/usr/local/lib -lereadline'


### PR DESCRIPTION
- Removed the HP-UX note, as I suspect it's no longer accurate.
- Added instructions for OpenBSD which should address #184.  We may be better off not expecting the more recent readline functionality, but I don't know either way on that.
- Added mention of `--with-readline` and `--without-readline`, and removed mention of editline, which I believe we have essentially given up on.
- Mentioned the requirement for POSIX.1-2001.