### PR TITLE
Ref() syntax errors thrown from $&parse

### DIFF
--- a/prim-etc.c
+++ b/prim-etc.c
@@ -183,9 +183,11 @@ PRIM(parse) {
 	Ref(Tree *, tree, NULL);
 	ExceptionHandler
 		tree = parse(prompt1, prompt2);
-	CatchException (e)
+	CatchException (ex)
+		Ref(List *, e, ex);
 		loginput(dumphistbuffer());
 		throw(e);
+		RefEnd(e);
 	EndExceptionHandler
 
 	loginput(dumphistbuffer());

--- a/test/tests/regression.es
+++ b/test/tests/regression.es
@@ -86,6 +86,9 @@ EOF
 	# this one actually would hang before the fix on systems with
 	# unsigned chars
 	assert {!$es -c 'echo hi |[2' >[2] /dev/null}
+
+	# https://github.com/wryun/es-shell/issues/199
+	assert {~ `` \n {echo 'fn-%write-history = $&collect'^\n^'cat << eof' | $es -i >[2=1]} *'incomplete here document'*}
 }
 
 # These tests are based on notes in the CHANGES file from the pre-git days.


### PR DESCRIPTION
Fixes #199.