### PR TITLE
Add special-case readline completion logic for first-position

### DIFF
--- a/access.c
+++ b/access.c
@@ -1,6 +1,5 @@
 /* access.c -- access testing and path searching ($Revision: 1.2 $) */
 
-#define	REQUIRE_STAT	1
 #define	REQUIRE_PARAM	1
 
 #include "es.h"
@@ -40,7 +39,7 @@ static Boolean ingroupset(gidset_t gid) {
 	return FALSE;
 }
 
-static int testperm(struct stat *stat, unsigned int perm) {
+extern int testperm(struct stat *stat, unsigned int perm) {
 	unsigned int mask;
 	static gidset_t uid, gid;
 	static Boolean initialized = FALSE;

--- a/es.h
+++ b/es.h
@@ -198,6 +198,7 @@ extern void setnoexport(List *list);
 extern void addtolist(void *arg, char *key, void *value);
 extern List *listvars(Boolean internal);
 extern List *varswithprefix(char *prefix);
+extern List *fnswithprefix(char *prefix);
 
 typedef struct Push Push;
 extern Push *pushlist;
@@ -216,6 +217,7 @@ extern void printstatus(int pid, int status);
 
 /* access.c */
 
+extern int testperm(struct stat *stat, unsigned int perm);
 extern char *checkexecutable(char *file);
 
 
@@ -283,7 +285,7 @@ extern void *erealloc(void *p, size_t n);
 extern void efree(void *p);
 extern void ewrite(int fd, const char *s, size_t n);
 extern long eread(int fd, char *buf, size_t n);
-extern Boolean isabsolute(char *path);
+extern Boolean isabsolute(const char *path);
 extern Boolean streq2(const char *s, const char *t1, const char *t2);
 
 

--- a/input.c
+++ b/input.c
@@ -566,16 +566,12 @@ static Boolean cmdstart(int point) {
 				state = PIPESTARTBRACKET;
 				break;
 			}
-			state = START; /* || correct? */
+			state = START; /* does this handle || correctly? */
 			/* fallthrough */
 		case START:
-			switch (c) {
-			case ' ': case '\t': case '\n': case '!':
-				break;
-			default:
-				state = NORMAL;
-			}
-			break;
+			if (c == ' ' || c == '\t' || c == '\n' || c == '!')
+				continue;
+			/* fallthrough */
 		case NORMAL:
 			switch (c) {
 			case '&': case '{': case '`':
@@ -588,7 +584,9 @@ static Boolean cmdstart(int point) {
 				state = LT;
 				break;
 			default:
-				break; /* nothing to do */
+				/* fallthroughs make this useful */
+				state = NORMAL;
+				break;
 			}
 		}
 	}

--- a/stdenv.h
+++ b/stdenv.h
@@ -44,9 +44,7 @@
 #include <sys/ioctl.h>
 #endif
 
-#if REQUIRE_STAT
 #include <sys/stat.h>
-#endif
 
 #if REQUIRE_DIRENT
 #if HAVE_DIRENT_H

--- a/util.c
+++ b/util.c
@@ -34,7 +34,7 @@ extern void uerror(char *s) {
 }
 
 /* isabsolute -- test to see if pathname begins with "/", "./", or "../" */
-extern Boolean isabsolute(char *path) {
+extern Boolean isabsolute(const char *path) {
 	return path[0] == '/'
 	       || (path[0] == '.' && (path[1] == '/'
 				      || (path[1] == '.' && path[2] == '/')));

--- a/var.c
+++ b/var.c
@@ -357,12 +357,27 @@ static void listwithprefix(void *arg, char *key, void *value) {
 		addtolist(arg, key, value);
 }
 
+static void fnwithprefix(void *arg, char *key, void *value) {
+	if (strneq(key, "fn-", 3) &&
+			strneq(key + 3, list_prefix, strlen(list_prefix)))
+		addtolist(arg, key + 3, value);
+}
+
 /* listvars -- return a list of all the (dynamic) variables */
 extern List *listvars(Boolean internal) {
 	Ref(List *, varlist, NULL);
 	dictforall(vars, internal ? listinternal : listexternal, &varlist);
 	varlist = sortlist(varlist);
 	RefReturn(varlist);
+}
+
+/* fnswithprefix -- return a list of all the (dynamic) functions
+ * matching the given prefix */
+extern List *fnswithprefix(char *prefix) {
+	Ref(List *, fnlist, NULL);
+	list_prefix = prefix;
+	dictforall(vars, fnwithprefix, &fnlist);
+	RefReturn(fnlist);
 }
 
 /* varswithprefix -- return a list of all the (dynamic) variables


### PR DESCRIPTION
We can't complete `%pathsearch`ed binaries, but we can complete some things in "first position".  So this adds:

 - A way to detect the start of commands when those happen in the middle of a line (like after a `;` or `&` or `|` or `{`).
 - Completion for syntactic forms at first position -- `local` `let` `for` `fn` `%closure` `match`
 - Function completion at first position
 - Completion for executable files and directories at absolute paths, but not other files, in first position

Shortcomings:
 - Start-of-command detection doesn't handle newlines-inside-`()` properly; I believe doing that would require a novel (within es) method of retaining previous-line state.
 - Paths starting with `~/` or `~username/` don't have filtering for whether they're executable, because I didn't want to bother with tilde expansion.

Possible further improvements for builtin completion:
 - variable-assignment completion? (like `path =`)
 - control primitive completion better -- right now you'll get primitive-completion if you already typed `$&`, but it should actually happen at start-of-command position
 - A variable to manually store the list of completable commands?

Of course, programmable completion based on semi-parsed input and something like #178 would be the "real", long-term goal, but this is a useful stop-gap and helps inform how its design would need to work.

A funny outcome of this change: `path-cache.es` makes it so that running a binary once makes that binary name complete-able from then on.

This code is getting messy... Also, my attitude for readline integration (somewhat unlike my attitude for the rest of the shell) is that these kinds of "80%-working" solutions are okay.  If other people want to vocally disagree with that, please do :)