### PR TITLE
Allocate memory from the parser in "pspace", not GC space

### DIFF
--- a/es.h
+++ b/es.h
@@ -136,7 +136,7 @@ extern List *sortlist(List *list);
 
 /* tree.c */
 
-extern Tree *mk(NodeKind VARARGS);
+extern Tree *gcmk(NodeKind VARARGS);	/* gcalloc a tree node */
 
 
 /* closure.c */
@@ -403,6 +403,12 @@ extern void gcreserve(size_t nbytes);		/* provoke a collection, if enabled and n
 extern void gcenable(void);			/* enable collections */
 extern void gcdisable(void);			/* disable collections */
 extern Boolean gcisblocked(void);		/* is collection disabled? */
+
+/* operations with pspace, the explicitly-collected gc space for parse tree building */
+extern void *palloc(size_t n, Tag *t);		/* allocate n with collection tag t, but in pspace */
+extern void *pseal(void *p);			/* collect pspace into gcspace with root p */
+extern char *pdup(const char *s);		/* copy a 0-terminated string into pspace */
+extern char *pndup(const char *s, size_t n);	/* copy a counted string into pspace */
 
 
 /*

--- a/gc.h
+++ b/gc.h
@@ -50,6 +50,8 @@ extern Buffer *bufcat(Buffer *buf, const char *s);
 extern Buffer *bufputc(Buffer *buf, char c);
 extern char *sealbuffer(Buffer *buf);
 extern char *sealcountedbuffer(Buffer *buf);
+extern char *psealbuffer(Buffer *buf);		/* pspace variant of sealbuffer */
+extern char *psealcountedbuffer(Buffer *buf);	/* pspace variant of sealcountedbuffer */
 extern void freebuffer(Buffer *buf);
 
 extern void *forward(void *p);

--- a/heredoc.c
+++ b/heredoc.c
@@ -22,7 +22,7 @@ extern Tree *getherevar(void) {
 	while ((c = GETC()) != EOF && !dnw[c])
 		buf = bufputc(buf, c);
 	len = buf->len;
-	s = sealcountedbuffer(buf);
+	s = psealcountedbuffer(buf);
 	if (len == 0) {
 		yyerror("null variable name in here document");
 		return NULL;
@@ -54,7 +54,7 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 			if (buf->current == 0 && tree != NULL)
 				freebuffer(buf);
 			else
-				*tailp = treecons(mk(nQword, sealcountedbuffer(buf)), NULL);
+				*tailp = treecons(mk(nQword, psealcountedbuffer(buf)), NULL);
 			break;
 		}
 		if (s != (unsigned char *) eof)
@@ -72,7 +72,7 @@ extern Tree *snarfheredoc(const char *eof, Boolean quoted) {
 				if (buf->current == 0)
 					freebuffer(buf);
 				else {
-					*tailp = treecons(mk(nQword, sealcountedbuffer(buf)), NULL);
+					*tailp = treecons(mk(nQword, psealcountedbuffer(buf)), NULL);
 					tailp = &(*tailp)->CDR;
 				}
 				var = getherevar();
@@ -133,7 +133,7 @@ extern Boolean queueheredoc(Tree *t) {
 		return FALSE;
 	}
 
-	here = gcalloc(sizeof (Here), NULL);
+	here = palloc(sizeof (Here), NULL);
 	here->next = hereq;
 	here->marker = eof;
 	hereq = here;

--- a/input.h
+++ b/input.h
@@ -43,7 +43,6 @@ extern void print_prompt2(void);
 
 extern Tree *parsetree;
 extern int yyparse(void);
-extern void initparse(void);
 
 
 /* heredoc.c */

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -191,7 +191,7 @@ PRIM(parse) {
 	loginput(dumphistbuffer());
 	result = (tree == NULL)
 		   ? NULL
-		   : mklist(mkterm(NULL, mkclosure(mk(nThunk, tree), NULL)),
+		   : mklist(mkterm(NULL, mkclosure(gcmk(nThunk, tree), NULL)),
 			    NULL);
 	RefEnd3(tree, prompt2, prompt1);
 	return result;

--- a/str.c
+++ b/str.c
@@ -15,7 +15,7 @@ static int str_grow(Format *f, size_t more) {
 }
 
 /* strv -- print a formatted string into gc space */
-extern char *strv(const char *fmt, va_list args) {
+static char *sstrv(char *(*seal)(Buffer *), const char *fmt, va_list args) {
 	Buffer *buf;
 	Format format;
 
@@ -37,7 +37,11 @@ extern char *strv(const char *fmt, va_list args) {
 	fmtputc(&format, '\0');
 	gcenable();
 
-	return sealbuffer(format.u.p);
+	return seal(format.u.p);
+}
+
+extern char *strv(const char *fmt, va_list args) {
+	return sstrv(sealbuffer, fmt, args);
 }
 
 /* str -- create a string (in garbage collection space) by printing to it */
@@ -46,6 +50,16 @@ extern char *str VARARGS1(const char *, fmt) {
 	va_list args;
 	VA_START(args, fmt);
 	s = strv(fmt, args);
+	va_end(args);
+	return s;
+}
+
+/* pstr -- create a string (in pspace) by printing to it */
+extern char *pstr VARARGS1(const char *, fmt) {
+	char *s;
+	va_list args;
+	VA_START(args, fmt);
+	s = sstrv(psealbuffer, fmt, args);
 	va_end(args);
 	return s;
 }

--- a/syntax.c
+++ b/syntax.c
@@ -8,11 +8,6 @@
 Tree errornode;
 Tree *parsetree;
 
-/* initparse -- called at the dawn of time */
-extern void initparse(void) {
-	globalroot(&parsetree);
-}
-
 /* treecons -- create new tree list cell */
 extern Tree *treecons(Tree *car, Tree *cdr) {
 	assert(cdr == NULL || cdr->kind == nList);
@@ -116,8 +111,8 @@ extern Tree *mkpipe(Tree *t1, int outfd, int infd, Tree *t2) {
 	Boolean pipetail;
 
 	pipetail = firstis(t2, "%pipe");
-	tail = prefix(str("%d", outfd),
-		      prefix(str("%d", infd),
+	tail = prefix(pstr("%d", outfd),
+		      prefix(pstr("%d", infd),
 			     pipetail ? t2->CDR : treecons(thunkify(t2), NULL)));
 	if (firstis(t1, "%pipe"))
 		return treeappend(t1, tail);
@@ -158,7 +153,7 @@ extern Tree *redirect(Tree *t) {
 }
 
 extern Tree *mkredircmd(char *cmd, int fd) {
-	return prefix(cmd, prefix(str("%d", fd), NULL));
+	return prefix(cmd, prefix(pstr("%d", fd), NULL));
 }
 
 extern Tree *mkredir(Tree *cmd, Tree *file) {
@@ -175,7 +170,7 @@ extern Tree *mkredir(Tree *cmd, Tree *file) {
 			yyerror("bad /dev/fd redirection");
 			op = "";
 		}
-		var = mk(nWord, str("_devfd%d", id++));
+		var = mk(nWord, pstr("_devfd%d", id++));
 		cmd = treecons(
 			mk(nWord, op),
 			treecons(var, NULL)
@@ -197,14 +192,14 @@ extern Tree *mkredir(Tree *cmd, Tree *file) {
 
 /* mkclose -- make a %close node with a placeholder */
 extern Tree *mkclose(int fd) {
-	return prefix("%close", prefix(str("%d", fd), treecons(&placeholder, NULL)));
+	return prefix("%close", prefix(pstr("%d", fd), treecons(&placeholder, NULL)));
 }
 
 /* mkdup -- make a %dup node with a placeholder */
 extern Tree *mkdup(int fd0, int fd1) {
 	return prefix("%dup",
-		      prefix(str("%d", fd0),
-			     prefix(str("%d", fd1),
+		      prefix(pstr("%d", fd0),
+			     prefix(pstr("%d", fd1),
 				    treecons(&placeholder, NULL))));
 }
 

--- a/syntax.h
+++ b/syntax.h
@@ -4,6 +4,11 @@
 #define	CDR	u[1].p
 
 
+/* tree.c */
+
+extern Tree *mk(NodeKind VARARGS);	/* palloc a tree node */
+
+
 /* syntax.c */
 
 extern Tree errornode;
@@ -30,6 +35,10 @@ extern Tree *redirappend(Tree *t, Tree *r);
 extern Tree *firstprepend(Tree *first, Tree *args);
 
 extern Tree *mkmatch(Tree *subj, Tree *cases);
+
+/* str.c */
+
+extern char *pstr(const char *fmt VARARGS);
 
 /* heredoc.c */
 

--- a/token.c
+++ b/token.c
@@ -195,7 +195,7 @@ top:	while ((c = GETC()) == ' ' || c == '\t')
 		else if (streq(buf, "match"))
 			return MATCH;
 		w = RW;
-		y->str = gcdup(buf);
+		y->str = pdup(buf);
 		return WORD;
 	}
 	if (c == '`' || c == '!' || c == '$' || c == '\'' || c == '=') {
@@ -244,7 +244,7 @@ top:	while ((c = GETC()) == ' ' || c == '\t')
 		}
 		UNGETC(c);
 		buf[i] = '\0';
-		y->str = gcdup(buf);
+		y->str = pdup(buf);
 		return QWORD;
 	case '\\':
 		if ((c = GETC()) == '\n') {
@@ -306,7 +306,7 @@ top:	while ((c = GETC()) == ' ' || c == '\t')
 			break;
 		}
 		buf[1] = 0;
-		y->str = gcdup(buf);
+		y->str = pdup(buf);
 		return QWORD;
 	case '#':
 		while ((c = GETC()) != '\n') /* skip comment until newline */


### PR DESCRIPTION
This change itself does not change anything for the user -- as far as I can tell, it doesn't even have a noticeable performance or memory-use impact to speak of.  It does add some code complexity, but I believe it's worth it.

The upside of this change is that it removes the major technical blocker for running _es_ functions while fetching input -- meaning that things like programmable key bindings, completions, line-by-line history-writing (as opposed to the per-command history writing after #65), and more (see #178) are all now possible with this change.

How it works is that it defines a new memory "space" called "pspace", where any parser-related GC-like memory allocations go.  Unlike normal GC space, pspace is never automatically collected, and is in fact manually collected at the end of a parse run.  Live data during pspace collection (called `pseal` in the codebase) is copied into GC space where it begins to act like any other GC'd data.  This makes "pspace" into a sort of special-purpose "nursery" like for a generational GC.

The next follow-up to this will be making it possible to run more than one parser at a time, such that _es_ code that needs to be parsed from a string before running can do so when the parser is already active.  After that, the sky is the limit.