### PR TITLE
Trust startup signals by default

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -184,18 +184,10 @@ extern void initsignals(Boolean interactive, Boolean allowdumps) {
 			sigeffect[sig] = sig_ignore;
 		}
 #endif /* !HAVE_SIGACTION */
-		else if (h == SIG_DFL || h == SIG_ERR)
-			sigeffect[sig] = sig_default;
 		else {
-#if TRUST_INCOMING_SIGNAL_HANDLERS
 			sigeffect[sig] = sig_default;
-			handler_in[sig] = h;
-#else
-			panic(
-				"initsignals: bad incoming signal value for %s: %x",
-				signame(sig), h
-			);
-#endif
+			if (h != SIG_ERR)
+				handler_in[sig] = h;
 		}
 	}
 


### PR DESCRIPTION
This obsoletes the `TRUST_INCOMING_SIGNAL_HANDLERS` define by making it always apply.

Previously, _es_ would crash if it started up with any signal handler set other than `SIG_DFL` or `SIG_IGN`.  This blocked certain development tools like asan and gprof, so I added this build flag in #167 to help those cases.  However, it seems certain targets these days also use this to simply use the shell normally (see #183), so it's worth making it the default.

Fixes #183.