### PR TITLE
lexer: ensure word state is NW before parsing CALL

### DIFF
--- a/test/tests/regression.es
+++ b/test/tests/regression.es
@@ -89,6 +89,9 @@ EOF
 
 	# https://github.com/wryun/es-shell/issues/199
 	assert {~ `` \n {echo 'fn-%write-history = $&collect'^\n^'cat << eof' | $es -i >[2=1]} *'incomplete here document'*}
+
+	# https://github.com/wryun/es-shell/issues/206
+	assert {~ `` \n {$es -c 'let (a=<=true) echo $a'} <=true} 'concatenated assignment+call syntax works'
 }
 
 # These tests are based on notes in the CHANGES file from the pre-git days.

--- a/token.c
+++ b/token.c
@@ -369,9 +369,10 @@ top:	while ((c = GETC()) == ' ' || c == '\t')
 				cmd = "%here";
 			} else
 				cmd = "%heredoc";
-		else if (c == '=')
+		else if (c == '=') {
+			w = NW;
 			return CALL;
-		else
+		} else
 			cmd = "%open";
 		goto redirection;
 	case '>':


### PR DESCRIPTION
The `=` character is treated like `!` in the lexer, to make `InsertFreeCaret()` do something both before and after the `=` character.
Unfortunately, this means `=` sets the word state to "keyword" and gets passed to the parser, `CALL` is read and passed to the parser without changing the word state, `b` is read, resulting in `InsertFreeCaret()` inserting a free caret to produce `a ^ = <= ^ b`, and a syntax error is born.
This doesn't happen with `a=<={b}` or other "redirection" byte sequences because they already set the word state to "nonword" before anything else is parsed.

In other words, the fix is simple&mdash;just make the word state "nonword" before passing `CALL` to the parser.