### PR TITLE
Fix minor compiler complaints

### DIFF
--- a/access.c
+++ b/access.c
@@ -29,10 +29,12 @@ static Boolean ingroupset(gidset_t gid) {
 	static gidset_t *gidset;
 	static Boolean initialized = FALSE;
 	if (!initialized) {
-		initialized = TRUE;
-		ngroups = getgroups(0, gidset);
+		ngroups = getgroups(0, NULL);
+		if (ngroups == -1)
+			fail("$&access", "getgroups: %s", esstrerror(errno));
 		gidset = ealloc(ngroups * sizeof(gidset_t));
-		getgroups(ngroups, gidset);
+		assert(getgroups(ngroups, gidset) != -1);
+		initialized = TRUE;
 	}
 	for (i = 0; i < ngroups; i++)
 		if (gid == gidset[i])

--- a/history.c
+++ b/history.c
@@ -39,7 +39,7 @@ static char history_comment_char = '#';
  */
 
 
-extern void newhistbuffer() {
+extern void newhistbuffer(void) {
 	assert(histbuffer == NULL);
 	histbuffer = openbuffer(BUFSIZE);
 }
@@ -50,7 +50,7 @@ extern void addhistbuffer(char c) {
 	histbuffer = bufputc(histbuffer, c);
 }
 
-extern char *dumphistbuffer() {
+extern char *dumphistbuffer(void) {
 	char *s;
         size_t len;
 	assert(histbuffer != NULL);

--- a/prim-io.c
+++ b/prim-io.c
@@ -180,7 +180,8 @@ PRIM(here) {
 	Ref(List *, cmd, tail);
 #ifdef PIPE_BUF
 	if (doclen <= PIPE_BUF) {
-		pipe(p);
+		if (pipe(p) == -1)
+			fail("$&here", "pipe: %s", esstrerror(errno));
 		ewrite(p[1], doc, doclen);
 	} else
 #endif


### PR DESCRIPTION
- Use some libc return values (seen when building with -D_FORTIFY_SOURCE=2)
- function defined as func() => func(void)

Related to #3.