### PR TITLE
"Fix" backtracking performance blow-up in globbing

### DIFF
--- a/match.c
+++ b/match.c
@@ -78,6 +78,8 @@ extern Boolean match(const char *s, const char *p, const char *q) {
 				next.s = *s ? s+1 : NULL;
 				continue;
 			case '[': {
+				if (!*s)
+					return FALSE;
 				int r = 1 + rangematch(p+1, QX(q, q+1, q), *s);
 				if (r > 0) {
 					p += r; s++;

--- a/match.c
+++ b/match.c
@@ -21,32 +21,31 @@ enum { RANGE_FAIL = -1, RANGE_ERROR = -2 };
 
 #define	ISQUOTED(q, n)	((q) == QUOTED || ((q) != UNQUOTED && (q)[n] == 'q'))
 #define TAILQUOTE(q, n) ((q) == UNQUOTED ? UNQUOTED : ((q) + (n)))
+#define QX(q, texpr, fexpr) (((q) != QUOTED && (q) != UNQUOTED) ? (texpr) : (fexpr))
 
 /* rangematch -- match a character against a character class */
 static int rangematch(const char *p, const char *q, char c) {
 	const char *orig = p;
 	Boolean neg;
 	Boolean matched = FALSE;
-	Boolean advanceq = (q != QUOTED && q != UNQUOTED);
-#define QX(expr) (advanceq ? (expr) : 0)
 	if (*p == '~' && !ISQUOTED(q, 0)) {
-		p++, QX(q++);
+		p++, QX(q, q++, 0);
 	    	neg = TRUE;
 	} else
 		neg = FALSE;
 	if (*p == ']' && !ISQUOTED(q, 0)) {
-		p++, QX(q++);
+		p++, QX(q, q++, 0);
 		matched = (c == ']');
 	}
-	for (; *p != ']' || ISQUOTED(q, 0); p++, QX(q++)) {
+	for (; *p != ']' || ISQUOTED(q, 0); p++, QX(q, q++, 0)) {
 		if (*p == '\0')
-			return RANGE_ERROR;	/* bad syntax */
+			return c == '[' ? 0 : RANGE_FAIL;	/* no right bracket */
 		if (p[1] == '-' && !ISQUOTED(q, 1) && ((p[2] != ']' && p[2] != '\0') || ISQUOTED(q, 2))) {
 			/* check for [..-..] but ignore [..-] */
 			if (c >= *p && c <= p[2])
 				matched = TRUE;
 			p += 2;
-			QX(q += 2);
+			QX(q, q += 2, 0);
 		} else if (*p == c)
 			matched = TRUE;
 	}
@@ -54,64 +53,61 @@ static int rangematch(const char *p, const char *q, char c) {
 		return p - orig + 1; /* skip the right-bracket */
 	else
 		return RANGE_FAIL;
-#undef QX
 }
 
 /* match -- match a single pattern against a single string. */
 extern Boolean match(const char *s, const char *p, const char *q) {
-	int i;
+	struct { const char *s, *p, *q; } next;
 	if (q == QUOTED)
 		return streq(s, p);
-	for (i = 0;;) {
-		int c = p[i++];
-		if (c == '\0')
-			return *s == '\0';
-		else if (q == UNQUOTED || q[i - 1] == 'r') {
-			switch (c) {
+	next.s = NULL;
+	while (*s || *p) {
+		if (*p) {
+			if (q != UNQUOTED && *q != 'r')
+				goto literal_char;
+			switch (*p) {
 			case '?':
-				if (*s++ == '\0')
-					return FALSE;
+				if (*s) {
+					p++; s++; QX(q, q++, 0);
+					continue;
+				}
 				break;
 			case '*':
-				while (p[i] == '*' && (q == UNQUOTED || q[i] == 'r'))	/* collapse multiple stars */
-					i++;
-				if (p[i] == '\0') 	/* star at end of pattern? */
-					return TRUE;
-				while (*s != '\0')
-					if (match(s++, p + i, TAILQUOTE(q, i)))
-						return TRUE;
-				return FALSE;
+				next.p = p++;
+				next.q = QX(q, q++, q);
+				next.s = *s ? s+1 : NULL;
+				continue;
 			case '[': {
-				int j;
-				if (*s == '\0')
-					return FALSE;
-				switch (j = rangematch(p + i, TAILQUOTE(q, i), *s)) {
-				default:
-					i += j;
-					break;
-				case RANGE_FAIL:
-					return FALSE;
-				case RANGE_ERROR:
-					if (*s != '[')
-						return FALSE;
+				int r = 1 + rangematch(p+1, QX(q, q+1, q), *s);
+				if (r > 0) {
+					p += r; s++;
+					q = QX(q, q + r, q);
+					continue;
 				}
-				s++;
 				break;
 			}
 			default:
-				if (c != *s++)
-					return FALSE;
+			literal_char:
+				if (*s == *p) {
+					p++; s++; QX(q, q++, 0);
+					continue;
+				}
 			}
-		} else if (c != *s++)
+		}
+		if (next.s == NULL)
 			return FALSE;
+		s = next.s;
+		p = next.p;
+		q = next.q;
 	}
+	return TRUE;
 }
 
 
 /*
  * listmatch
  *
- * 	Matches a list of words s against a list of patterns p.
+ *	Matches a list of words s against a list of patterns p.
  *	Returns true iff a pattern in p matches a word in s.
  *	() matches (), but otherwise null patterns match nothing.
  */

--- a/test/tests/glob.es
+++ b/test/tests/glob.es
@@ -17,3 +17,28 @@ test 'file globbing' {
 		}
 	}
 }
+
+# From https://research.swtch.com/glob.go
+test 'asterisk patterns' {
+	for ((test want) = (
+		{~	''	''}	true
+		{~	x	''}	false
+		{~	''	x}	false
+		{~	abc	abc}	true
+		{~	abc	*}	true
+		{~	abc	*c}	true
+		{~	abc	*b}	false
+		{~	abc	a*}	true
+		{~	abc	b*}	false
+		{~	a	a*}	true
+		{~	a	*a}	true
+		{~	axbxcxdxe	a*b*c*d*e*}	true
+		{~	axbxcxdxexxx	a*b*c*d*e*}	true
+		{~	abxbbxdbxebxczzx	a*b?c*x}	true
+		{~	abxbbxdbxebxczzy	a*b?c*x}	false
+		{~	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	a*a*a*a*b}	false
+		{~	xxx	*x}	true
+	)) {
+		assert {~ <={$test} <={$want}}
+	}
+}

--- a/test/tests/glob.es
+++ b/test/tests/glob.es
@@ -21,23 +21,39 @@ test 'file globbing' {
 # From https://research.swtch.com/glob.go
 test 'asterisk patterns' {
 	for ((test want) = (
-		{~	''	''}	true
-		{~	x	''}	false
-		{~	''	x}	false
-		{~	abc	abc}	true
-		{~	abc	*}	true
-		{~	abc	*c}	true
-		{~	abc	*b}	false
-		{~	abc	a*}	true
-		{~	abc	b*}	false
-		{~	a	a*}	true
-		{~	a	*a}	true
-		{~	axbxcxdxe	a*b*c*d*e*}	true
-		{~	axbxcxdxexxx	a*b*c*d*e*}	true
-		{~	abxbbxdbxebxczzx	a*b?c*x}	true
-		{~	abxbbxdbxebxczzy	a*b?c*x}	false
-		{~	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	a*a*a*a*b}	false
-		{~	xxx	*x}	true
+		{~ ''	''}	true
+		{~ x	''}	false
+		{~ ''	x}	false
+		{~ abc	abc}	true
+		{~ abc	*}	true
+		{~ abc	*c}	true
+		{~ abc	*b}	false
+		{~ abc	a*}	true
+		{~ abc	b*}	false
+		{~ a	a*}	true
+		{~ a	*a}	true
+		{~ axbxcxdxe	a*b*c*d*e*}	true
+		{~ axbxcxdxexxx	a*b*c*d*e*}	true
+		{~ abxbbxdbxebxczzx	a*b?c*x}	true
+		{~ abxbbxdbxebxczzy	a*b?c*x}	false
+		{~ xxx	*x}	true
+		{~ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	a*a*a*a*b}	false
+	)) {
+		assert {~ <={$test} <={$want}}
+	}
+}
+
+test 'range patterns' {
+	for ((test want) = (
+		{~ x  [x]}	true
+		{~ x  [y]}	false
+		{~ x  [xyz]}	true
+		{~ y  [xyz]}	true
+		{~ z  [xyz]}	true
+		{~ x  [xy  }	false
+		{~ px p[~a]}	true
+		{~ pa p[~a]}	false
+		{~ p  p[~a]}	false	# https://github.com/rakitzis/rc/issues/115
 	)) {
 		assert {~ <={$test} <={$want}}
 	}

--- a/test/tests/glob.es
+++ b/test/tests/glob.es
@@ -45,15 +45,32 @@ test 'asterisk patterns' {
 
 test 'range patterns' {
 	for ((test want) = (
-		{~ x  [x]}	true
-		{~ x  [y]}	false
-		{~ x  [xyz]}	true
-		{~ y  [xyz]}	true
-		{~ z  [xyz]}	true
-		{~ x  [xy  }	false
+		{~ x [x]}	true
+		{~ x [y]}	false
+		{~ x [xyz]}	true
+		{~ y [xyz]}	true
+		{~ z [xyz]}	true
+		{~ x [xy  }	false
+		{~ [xy  [xy }	true
+		{~ [xy] [xy]}	false
 		{~ px p[~a]}	true
 		{~ pa p[~a]}	false
 		{~ p  p[~a]}	false	# https://github.com/rakitzis/rc/issues/115
+		{~ pa p[a~]}	true
+		{~ p~ p[a~]}	true
+		{~ ab a[a-z]b}	false
+		{~ axb a[a-z]b}	true
+		{~ a-b a[a-z]b}	false
+		{~ a-b a[-az]b}	true
+		{~ axb a[-az]b}	false
+		{~ azb a[-az]b}	true
+		{~ a-b a[a\-z]b}	true
+		{~ axb a[a\-z]b}	false
+		{~ azb a[a\-z]b}	true
+		{~ axb a[~a-z]b}	false
+		{~ a-b a[~a-z]b}	true
+		{~ axb a[a-z~]b}	true
+		{~ a-b a[a-z~]b}	false
 	)) {
 		assert {~ <={$test} <={$want}}
 	}


### PR DESCRIPTION
Fixes #208.

This resolves a performance corner-case that I'm not sure anyone has ever actually hit, but at the same time it mildly simplifies the `match()` algorithm in a satisfying way.

Also adds a few test cases for matching against these patterns.

Verified performance benefit:
```
; touch aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
; es.old -c 'time {echo a*a*a*a*a*a*a*b}'
a*a*a*a*a*a*a*b
    39r    39.5u     0.0s	{echo a*a*a*a*a*a*a*b}
; es.new -c 'time {echo a*a*a*a*a*a*a*b}'
a*a*a*a*a*a*a*b
     0r     0.0u     0.0s	{echo a*a*a*a*a*a*a*b}
```