### PR TITLE
Make GCALWAYS GC more, and fix memory bugs

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -347,12 +347,15 @@ extern Binding *bindargs(Tree *params, List *args, Binding *binding) {
 
 /* pathsearch -- evaluate fn %pathsearch + some argument */
 extern List *pathsearch(Term *term) {
-	List *search, *list;
+	List *list;
+	Ref(List *, search, NULL);
 	search = varlookup("fn-%pathsearch", NULL);
 	if (search == NULL)
 		fail("es:pathsearch", "%E: fn %%pathsearch undefined", term);
 	list = mklist(term, NULL);
-	return eval(append(search, list), NULL, 0);
+	list = append(search, list);
+	RefEnd(search);
+	return eval(list, NULL, 0);
 }
 
 /* eval -- evaluate a list, producing a list */

--- a/gc.c
+++ b/gc.c
@@ -363,7 +363,11 @@ static void scanspace(void) {
 extern void gcenable(void) {
 	assert(gcblocked > 0);
 	--gcblocked;
+#if GCALWAYS
+	if (!gcblocked)
+#else
 	if (!gcblocked && new->next != NULL)
+#endif
 		gc();
 }
 

--- a/prim-io.c
+++ b/prim-io.c
@@ -174,10 +174,10 @@ PRIM(here) {
 		;
 	*tailp = NULL;
 
+	Ref(List *, cmd, tail);
 	Ref(char *, doc, (lp == tail) ? NULL : str("%L", lp, ""));
 	doclen = strlen(doc);
 
-	Ref(List *, cmd, tail);
 #ifdef PIPE_BUF
 	if (doclen <= PIPE_BUF) {
 		if (pipe(p) == -1)
@@ -210,7 +210,7 @@ PRIM(here) {
 		status = ewaitfor(pid);
 		printstatus(0, status);
 	}
-	RefEnd2(cmd, doc);
+	RefEnd2(doc, cmd);
 	RefReturn(lp);
 }
 

--- a/term.c
+++ b/term.c
@@ -34,13 +34,15 @@ extern Closure *getclosure(Term *term) {
 			|| (*s == '$' && s[1] == '&')
 			|| hasprefix(s, "%closure")
 		) {
+			Closure *c;
 			Ref(Term *, tp, term);
 			Ref(Tree *, np, parsestring(s));
 			if (np == NULL) {
 				RefPop2(np, tp);
 				return NULL;
 			}
-			tp->closure = extractbindings(np);
+			c = extractbindings(np);
+			tp->closure = c;
 			tp->str = NULL;
 			term = tp;
 			RefEnd2(np, tp);


### PR DESCRIPTION
This PR changes `GCALWAYS` to trigger a GC on every (non-GC-blocked) call to `gcenable()`.  This reveals a few memory bugs which have been lurking.  This started when I started running into one particular bug in a repeatable way; the rest of this first comment describes the fix for that one issue, before I got more to the bottom of all this.

---

I don't fully understand the issue here (nor do I have a testable repro), but this fixes a memory bug manifesting as segfaults and closure assertion failures, caused, I believe, by bad ordering between lvalue evaluation and GC.  Adding a temp variable forces the right thing to happen.

As I see it, the issue can be illustrated with the following minimal example in C:
```c
#include <stdlib.h>
#include <stdio.h>

int *s;

int set(int i) {
	s = malloc(sizeof(int));
	*s = 666;
	return i;
}

int main() {
	s = malloc(sizeof(int));
	*s = 1;
	*s = set(2);
	printf("%d\n", *s);
}
```
When run on my machine, this prints `666`.  This shows that when `s` is reallocated in `set()`, the (old) memory location of `s` used on the left hand of the assignment in `main()` becomes useless.  I believe this is also what happens in the `term.c` segment being changed in this PR; `tp->closure` is evaluated to a memory location, then `extractbindings()` is called, which triggers a GC, moving the live value of `tp`, and then a value is returned and the `closure` entry _of the now-garbage `tp`_ is assigned.

What I'm uncertain and a bit queasy about is why this bug is so hard to trigger.  If the above explanation is correct, shouldn't it cause problems pretty much immediately when the shell is compiled with `-DGCDEBUG=1`?  Why is it only a very occasional issue?