### PR TITLE
Check for signal interruptions in empty commands

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -371,8 +371,7 @@ extern List *eval(List *list0, Binding *binding0, int flags) {
 	Ref(char *, funcname, NULL);
 
 restart:
-	if (interrupted)
-		SIGCHK();
+	SIGCHK();
 	if (list == NULL) {
 		RefPop3(funcname, binding, list);
 		--evaldepth;


### PR DESCRIPTION
`$&forever` with no arguments creates an uninterruptible loop, requiring the shell to be killed.
Other primitives in the future may fall into the same trap, so this is a general-purpose fix.