### PR TITLE
Reduce use of, and simplify, slow syscall handling

### DIFF
--- a/es.h
+++ b/es.h
@@ -282,7 +282,6 @@ extern void *ealloc(size_t n);
 extern void *erealloc(void *p, size_t n);
 extern void efree(void *p);
 extern void ewrite(int fd, const char *s, size_t n);
-#define eread read
 extern Boolean isabsolute(char *path);
 extern Boolean streq2(const char *s, const char *t1, const char *t2);
 

--- a/es.h
+++ b/es.h
@@ -282,10 +282,9 @@ extern void *ealloc(size_t n);
 extern void *erealloc(void *p, size_t n);
 extern void efree(void *p);
 extern void ewrite(int fd, const char *s, size_t n);
-extern long eread(int fd, char *buf, size_t n);
+#define eread read
 extern Boolean isabsolute(char *path);
 extern Boolean streq2(const char *s, const char *t1, const char *t2);
-
 
 /* input.c */
 
@@ -365,7 +364,7 @@ extern void setsigeffects(const Sigeffect effects[]);
 extern void getsigeffects(Sigeffect effects[]);
 extern List *mksiglist(void);
 extern void initsignals(Boolean interactive, Boolean allowdumps);
-extern Atomic slow, interrupted;
+extern Atomic slow;
 extern jmp_buf slowlabel;
 extern Boolean sigint_newline;
 extern void sigchk(void);

--- a/input.c
+++ b/input.c
@@ -193,7 +193,7 @@ static int fdfill(Input *in) {
 	} else
 #endif
 	do {
-		nread = eread(in->fd, (char *) in->bufbegin, in->buflen);
+		nread = read(in->fd, (char *) in->bufbegin, in->buflen);
 		SIGCHK();
 	} while (nread == -1 && errno == EINTR);
 

--- a/input.c
+++ b/input.c
@@ -150,12 +150,9 @@ static char *callreadline(char *prompt0) {
 	}
 	if (RL_ISSTATE(RL_STATE_INITIALIZED))
 		rl_reset_screen_size();
-	interrupted = FALSE;
 	if (!setjmp(slowlabel)) {
 		slow = TRUE;
-		r = interrupted ? NULL : readline(prompt);
-		if (interrupted)
-			errno = EINTR;
+		r = readline(prompt);
 	} else {
 		r = NULL;
 		errno = EINTR;

--- a/prim-io.c
+++ b/prim-io.c
@@ -365,7 +365,7 @@ static List *bqinput(const char *sep, int fd) {
 
 restart:
 	/* avoid SIGCHK()ing in here so we don't abandon our child process */
-	while ((n = eread(fd, in, sizeof in)) > 0)
+	while ((n = read(fd, in, sizeof in)) > 0)
 		splitstring(in, n, FALSE);
 	if (n == -1) {
 		if (errno == EINTR)
@@ -418,7 +418,7 @@ static int read1(int fd) {
 	int nread;
 	unsigned char buf;
 	do {
-		nread = eread(fd, (char *) &buf, 1);
+		nread = read(fd, (char *) &buf, 1);
 		SIGCHK();
 	} while (nread == -1 && errno == EINTR);
 	if (nread == -1)

--- a/signal.c
+++ b/signal.c
@@ -7,13 +7,18 @@ typedef void (*Sighandler)(int);
 
 Boolean sigint_newline = TRUE;
 
-jmp_buf slowlabel;
-Atomic slow = FALSE;
-Atomic interrupted = FALSE;
 static Atomic sigcount;
 static Atomic caught[NSIG];
 static Sigeffect sigeffect[NSIG];
 static Sighandler handler_in[NSIG];
+
+/*
+ * these variables are for the purpose of forcing a "return" from library or
+ * system calls when a signal is received, since some of them don't do that
+ * themselves.
+ */
+jmp_buf slowlabel;
+Atomic slow = FALSE;
 
 #if HAVE_SIGACTION
 #ifndef	SA_NOCLDSTOP
@@ -79,7 +84,6 @@ static void catcher(int sig) {
 		caught[sig] = TRUE;
 		++sigcount;
 	}
-	interrupted = TRUE;
 	if (slow)
 		longjmp(slowlabel, 1);
 }

--- a/util.c
+++ b/util.c
@@ -98,35 +98,7 @@ extern void ewrite(int fd, const char *buf, size_t n) {
 	volatile long i, remain;
 	const char *volatile bufp = buf;
 	for (i = 0, remain = n; remain > 0; bufp += i, remain -= i) {
-		interrupted = FALSE;
-		if (!setjmp(slowlabel)) {
-			slow = TRUE;
-			if (interrupted)
-				break;
-			else if ((i = write(fd, bufp, remain)) <= 0)
-				break; /* abort silently on errors in write() */
-		} else
-			break;
-		slow = FALSE;
+		if ((i = write(fd, bufp, remain)) < 0 && errno != EINTR)
+			break; /* abort silently on errors in write() */
 	}
-	slow = FALSE;
-}
-
-extern long eread(int fd, char *buf, size_t n) {
-	long r;
-	interrupted = FALSE;
-	if (!setjmp(slowlabel)) {
-		slow = TRUE;
-		if (!interrupted)
-			r = read(fd, buf, n);
-		else
-			r = -2;
-	} else
-		r = -2;
-	slow = FALSE;
-	if (r == -2) {
-		errno = EINTR;
-		r = -1;
-	}
-	return r;
 }


### PR DESCRIPTION
This should resolve #224.

We remove the `slow`/`slowlabel` wrapping around `read` and `write`, which is unnecessary on POSIX.1-2001 compliant systems.  This helps simplify some code, and could lead to more-correct behavior, given the `slow`/`slowlabel` wrapping was problematic when used with `waitpid`.  This leaves this behavior only used with `readline()`; jumping out of the signal handler seems to be the best (and only?) way to exit from `readline()` calls when receiving signals.

We also remove the `interrupted` variable, as it seems redundant with surrounding code.  This helps simplify control flow and (slightly) reduces the number of globals.

It might be nice to get `slow` and `slowlabel` removed entirely, but I believe the complexity that would add to `readline()` invocation would be greater than the simplification achieved, especially if we're trying not to use any sort of fancy new readline features.  I'm open to someone better at programming readline to prove me wrong on that, though.  I did add a comment to try to explain what `slow` and `slowlabel` are there for.

This PR should definitely get testing on other Unices before being merged.