### PR TITLE
Tidy up lexical scope.

### DIFF
--- a/es.h
+++ b/es.h
@@ -174,7 +174,7 @@ extern List *glom2(Tree *tree, Binding *binding, StrList **quotep);
 /* glob.c */
 
 extern char QUOTED[], UNQUOTED[];
-extern List *glob(List *list, StrList *quote);
+extern List *glob(List *list, StrList *quote, Binding *binding);
 extern Boolean haswild(const char *pattern, const char *quoting);
 
 
@@ -335,7 +335,7 @@ extern List *esoptend(void);
 
 /* prim.c */
 
-extern List *prim(char *s, List *list, Binding *binding, int evalflags);
+extern List *prim(char *s, List *list, int evalflags);
 extern void initprims(void);
 extern List *primswithprefix(char *prefix);
 

--- a/eval.c
+++ b/eval.c
@@ -383,7 +383,7 @@ restart:
 		switch (cp->tree->kind) {
 		    case nPrim:
 			assert(cp->binding == NULL);
-			list = prim(cp->tree->u[0].s, list->next, binding, flags);
+			list = prim(cp->tree->u[0].s, list->next, flags);
 			break;
 		    case nThunk:
 			list = walk(cp->tree->u[0].p, cp->binding, flags);

--- a/glob.c
+++ b/glob.c
@@ -195,10 +195,10 @@ static List *glob0(List *list, StrList *quote) {
 }
 
 /* expandhome -- do tilde expansion by calling fn %home */
-static char *expandhome(char *s, StrList *qp) {
+static char *expandhome(char *s, StrList *qp, Binding *binding) {
 	int c;
 	size_t slash;
-	List *fn = varlookup("fn-%home", NULL);
+	List *fn = varlookup("fn-%home", binding);
 
 	assert(*s == '~');
 	assert(qp->str == UNQUOTED || *qp->str == 'r');
@@ -259,7 +259,7 @@ static char *expandhome(char *s, StrList *qp) {
 }
 
 /* glob -- globbing prepass (glob if we need to, and dispatch for tilde expansion) */
-extern List *glob(List *list, StrList *quote) {
+extern List *glob(List *list, StrList *quote, Binding *binding) {
 	List *lp;
 	StrList *qp;
 	Boolean doglobbing = FALSE;
@@ -276,7 +276,7 @@ extern List *glob(List *list, StrList *quote) {
 				Ref(List *, lr, lp);
 				Ref(StrList *, q0, quote);
 				Ref(StrList *, qr, qp);
-				str = expandhome(str, qp);
+				str = expandhome(str, qp, binding);
 				tmp = mkstr(str);
 				lr->term = tmp;
 				lp = lr;

--- a/glom.c
+++ b/glom.c
@@ -321,7 +321,7 @@ extern List *glom(Tree *tree, Binding *binding, Boolean globit) {
 		Ref(List *, list, NULL);
 		Ref(StrList *, quote, NULL);
 		list = glom2(tree, binding, &quote);
-		list = glob(list, quote);
+		list = glob(list, quote, binding);
 		RefEnd(quote);
 		RefReturn(list);
 	} else

--- a/input.c
+++ b/input.c
@@ -301,7 +301,7 @@ extern List *runinput(Input *in, int runflags) {
 				   : "fn-%batch-loop",
 				 NULL);
 		result = (repl == NULL)
-				? prim("batchloop", NULL, NULL, flags)
+				? prim("batchloop", NULL, flags)
 				: eval(repl, NULL, flags);
 
 		varpop(&push);

--- a/prim-ctl.c
+++ b/prim-ctl.c
@@ -68,7 +68,6 @@ PRIM(catch) {
 				result
 				  = prim("noreturn",
 					 mklist(lp->term, frombody),
-					 NULL,
 					 evalflags);
 				unblocksignals();
 			CatchException (fromcatcher)

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -97,7 +97,7 @@ PRIM(whatis) {
 		List *fn;
 		Ref(char *, prog, getstr(term));
 		assert(prog != NULL);
-		fn = varlookup2("fn-", prog, binding);
+		fn = varlookup2("fn-", prog, NULL);
 		if (fn != NULL)
 			list = fn;
 		else {
@@ -141,7 +141,7 @@ PRIM(var) {
 	Ref(List *, rest, list->next);
 	Ref(char *, name, getstr(list->term));
 	Ref(List *, defn, varlookup(name, NULL));
-	rest = prim_var(rest, NULL, evalflags);
+	rest = prim_var(rest, evalflags);
 	term = mkstr(str("%S = %#L", name, defn, " "));
 	list = mklist(term, rest);
 	RefEnd3(defn, name, rest);
@@ -215,7 +215,7 @@ PRIM(batchloop) {
 			List *parser, *cmd;
 			parser = varlookup("fn-%parse", NULL);
 			cmd = (parser == NULL)
-					? prim("parse", NULL, NULL, 0)
+					? prim("parse", NULL, 0)
 					: eval(parser, NULL, 0);
 			SIGCHK();
 			dispatch = varlookup("fn-%dispatch", NULL);

--- a/prim.c
+++ b/prim.c
@@ -5,12 +5,12 @@
 
 static Dict *prims;
 
-extern List *prim(char *s, List *list, Binding *binding, int evalflags) {
+extern List *prim(char *s, List *list, int evalflags) {
 	Prim *p;
 	p = (Prim *) dictget(prims, s);
 	if (p == NULL)
 		fail("es:prim", "unknown primitive: %s", s);
-	return (p->prim)(list, binding, evalflags);
+	return (p->prim)(list, evalflags);
 }
 
 static char *list_prefix;

--- a/prim.h
+++ b/prim.h
@@ -1,9 +1,9 @@
 /* prim.h -- definitions for es primitives ($Revision: 1.1.1.1 $) */
 
-typedef struct { List *(*prim)(List *, Binding *, int); } Prim;
+typedef struct { List *(*prim)(List *, int); } Prim;
 
 #define	PRIM(name)	static List *CONCAT(prim_,name)( \
-				List UNUSED *list, Binding UNUSED *binding, int UNUSED evalflags \
+				List UNUSED *list, int UNUSED evalflags \
 			)
 #define	X(name)		STMT( \
 			static Prim CONCAT(prim_struct_,name) = { CONCAT(prim_,name) }; \


### PR DESCRIPTION
- Look up %home WITH lexical context, so that

    let (fn %home {result foo}) {echo ~}

  echoes 'foo'.  This makes it more like the syntactic-sugar primitives. Perhaps %home should be made into a syntactic-sugar primitive itself, but that's more effort for little gain.

- Remove `Binding *`s from primitives.  This only practically makes it so `$&whatis` can't return let-bound functions, which is fine because (1) it is very rare to let-bind a function definition and then, within that lexical block, ask "what is this function?", and (2) as soon as you wrap the `$&whatis` call in a lambda for something like `whatis`, you lose the lexical context anyway.  This behavior makes `$&whatis` and `whatis` consistent, without hacking in something to inject lexical context into lambdas.

Fixes #219, where lexical bindings and primitives got some discussion.