### PR TITLE
Fix memory bug in $&access

### DIFF
--- a/access.c
+++ b/access.c
@@ -164,11 +164,12 @@ PRIM(access) {
 	}
 
 	if (first && throws) {
-		gcenable();
+		Ref(char *, err, esstrerror(estatus));
 		if (suffix)
-			fail("$&access", "%s: %s", suffix, esstrerror(estatus));
-		else
-			fail("$&access", "%s", esstrerror(estatus));
+			err = str("%s: %s", suffix, err);
+		gcenable();
+		fail("$&access", err);
+		RefEnd(err);
 	}
 
 	Ref(List *, result, reverse(lp));

--- a/test/tests/access.es
+++ b/test/tests/access.es
@@ -7,6 +7,33 @@ test 'file permissions' {
 	assert {access -x $es}
 }
 
+test 'access exceptions' {
+	let (ex = ()) {
+		catch @ e {ex = $e} {
+			access -1e $es zzznonexistent
+		}
+		assert {~ $ex ()}
+	}
+	let (ex = ()) {
+		catch @ e {ex = $e} {
+			access -1e zzznonexistent $es
+		}
+		assert {~ $ex ()}
+	}
+	let (ex = ()) {
+		catch @ e {ex = $e} {
+			access -1e zzznonexistent xxxnonexistent
+		}
+		assert {!~ $ex ()}
+	}
+	let (ex = ()) {
+		catch @ e {ex = $e} {
+			access -n zzznonexistent -1e / .
+		}
+		assert {!~ $ex ()}
+	}
+}
+
 test 'file types' {
 	assert {access -d /}
 	assert {!access -d $es}


### PR DESCRIPTION
This is a tiny tiny corner case unlikely to actually be triggered, but it is possible for `gcenable()` to trigger a collection, which would make `suffix` invalid before its use in `fail()`.

This wasn't caught before because we didn't have any test coverage for this branch within `$&access`, and supposedly nobody has ever manually triggered the bug since #217 was merged.