### PR TITLE
Revive `esdebug`

### DIFF
--- a/esdebug
+++ b/esdebug
@@ -262,7 +262,7 @@ let (fn-while = $fn-while)
 fn-_debug = $&noreturn @ {
 	$&if {~ $1 break || $_stepping} {
 		<= {
-			while {
+			while true {
 				let (cmd = <={_get $_prompt}) {
 					$&seq {
 						while {~ $cmd(1) $_prompt} {


### PR DESCRIPTION
The `esdebug` script is a cool and useful bit of _es_, but it has been broken for a while.

This PR makes changes imposed by language drift over time so that `esdebug` can again be run like before.
 - Replace `#! /bin/es` with `#!/usr/local/bin/es`, reflecting the standard install location today
 - Replace `line` call with `%read`
 - Replace `return` with `result` where the exception behavior isn't necessary
 - Replace `$&while` with a lexically-captured `while`
 - Replace `dispatch` param to `%interactive-loop` with dynamically-defined `fn-%dispatch`
 - Handle `exit`'s change to an exception

The script is still pretty old and crufty, though, and there's quite a bit more that could be done as a follow-up to clean this up and make it more useful if we wanted to actually, say, distribute it with the shell.

 - Use lexically-bound `%seq` and `if` to get rid of the primitive madness
 - Lean on lexical binding harder in order to better isolate debugger state
 - Improve behavior around settor functions and `trap`/`trace`/`watch`
 - Test it and fix the bugs that are still too easy to run into
 - Document it, since debuggers tend to be complicated to use

Because I can't leave well enough alone, here are also some fancier things that could be done if runtime support were added:

 - A `$&readline` primitive (see #178) could make it nicer to use the debugger's prompt
 - A general `%set` hook (see #92) would make more robust tracing possible, especially with variables that already have settors
 - More customizable argument parsing related behavior (see #79) might make it possible to go into "debugger mode" with `. -D script.es`, or to even just drop into the debugger in the middle of a running shell session with something like `runflags = $runflags debug`