### PR TITLE
Fix using externally-sourced strings as fmt strings.

### DIFF
--- a/access.c
+++ b/access.c
@@ -168,7 +168,7 @@ PRIM(access) {
 		if (suffix)
 			err = str("%s: %s", suffix, err);
 		gcenable();
-		fail("$&access", err);
+		fail("$&access", "%s", err);
 		RefEnd(err);
 	}
 

--- a/prim-io.c
+++ b/prim-io.c
@@ -422,7 +422,7 @@ static int read1(int fd) {
 		SIGCHK();
 	} while (nread == -1 && errno == EINTR);
 	if (nread == -1)
-		fail("$&read", esstrerror(errno));
+		fail("$&read", "%s", esstrerror(errno));
 	return nread == 0 ? EOF : buf;
 }
 

--- a/test/tests/regression.es
+++ b/test/tests/regression.es
@@ -92,6 +92,9 @@ EOF
 
 	# https://github.com/wryun/es-shell/issues/206
 	assert {~ `` \n {$es -c 'let (a=<=true) echo $a'} <=true} 'concatenated assignment+call syntax works'
+
+	# https://github.com/wryun/es-shell/issues/235
+	assert {$es -c 'catch @ {} {%pathsearch %pnothingthatreallyexists}'} '%-like strings don''t break %pathsearch'
 }
 
 # These tests are based on notes in the CHANGES file from the pre-git days.


### PR DESCRIPTION
Fixes #235; verified with new regression test case.