### PR TITLE
Call sigsetjmp/siglongjmp directly in code

### DIFF
--- a/es.h
+++ b/es.h
@@ -364,7 +364,7 @@ extern void getsigeffects(Sigeffect effects[]);
 extern List *mksiglist(void);
 extern void initsignals(Boolean interactive, Boolean allowdumps);
 extern Atomic slow;
-extern jmp_buf slowlabel;
+extern sigjmp_buf slowlabel;
 extern Boolean sigint_newline;
 extern void sigchk(void);
 extern Boolean issilentsignal(List *e);
@@ -506,7 +506,7 @@ struct Handler {
 	Root *rootlist;
 	Push *pushlist;
 	unsigned long evaldepth;
-	jmp_buf label;
+	sigjmp_buf label;
 };
 
 extern Handler *tophandler, *roothandler;
@@ -530,7 +530,7 @@ extern List *raised(List *e);
 		_localhandler.evaldepth = evaldepth; \
 		_localhandler.up = tophandler; \
 		tophandler = &_localhandler; \
-		if (!setjmp(_localhandler.label)) {
+		if (!sigsetjmp(_localhandler.label, 0)) {
 	
 #define CatchException(e) \
 			pophandler(&_localhandler); \

--- a/except.c
+++ b/except.c
@@ -43,7 +43,7 @@ extern Noreturn throw(List *e) {
 	rootlist = handler->rootlist;
 #endif
 	exception = e;
-	longjmp(handler->label, 1);
+	siglongjmp(handler->label, 1);
 	NOTREACHED;
 }
 

--- a/input.c
+++ b/input.c
@@ -150,7 +150,7 @@ static char *callreadline(char *prompt0) {
 	}
 	if (RL_ISSTATE(RL_STATE_INITIALIZED))
 		rl_reset_screen_size();
-	if (!setjmp(slowlabel)) {
+	if (!sigsetjmp(slowlabel, 1)) {
 		slow = TRUE;
 		r = readline(prompt);
 	} else {

--- a/signal.c
+++ b/signal.c
@@ -85,7 +85,7 @@ static void catcher(int sig) {
 		++sigcount;
 	}
 	if (slow)
-		longjmp(slowlabel, 1);
+		siglongjmp(slowlabel, 1);
 }
 
 

--- a/stdenv.h
+++ b/stdenv.h
@@ -144,16 +144,10 @@ extern void *qsort(
 
 /* setjmp */
 
-#if defined sigsetjmp || HAVE_SIGSETJMP
-/* under linux, sigsetjmp and setjmp are both macros 
- * -- need to undef setjmp to avoid problems
- */
-# ifdef setjmp
-#  undef setjmp
-# endif
-# define setjmp(buf) sigsetjmp(buf,1)
-# define longjmp(x,y)     siglongjmp(x,y)
-# define jmp_buf     sigjmp_buf
+#if !defined sigsetjmp && !HAVE_SIGSETJMP
+#define	sigsetjmp(b,n)	setjmp(b)
+#define	siglongjmp(x,y)	longjmp(x,y)
+#define	sigjmp_buf	jmp_buf
 #endif
 
 


### PR DESCRIPTION
This lets us control when we do want to save the signal mask (i.e., when `longjmp`ing out of the signal handler) or don't (i.e., whenever we're just doing exceptions).

It's a bit more explicit, which is nice, given the "function X is actually slightly-different function Y" macrology can be confusing (I've been bitten by it in the past).

There's also a minor but possibly non-negligible performance benefit, since it makes the most common case, `setjmp` calls as part of `ExceptionHandler` macros, ~100x faster by cutting out a couple syscalls for each `setjmp()`.  This is a relatively tiny benefit, but given `ExceptionHandler` is called for every `$&parse`, `$&here`, redirection, lambda evaluation, every time a dynamically-scoped variable is popped, twice for each `$&catch`, and more, it seems reasonable to make this pretty tiny and simple optimization.  If #73 or something similar ever gets merged such that `if` and `<=` also catch certain exceptions, then this would help even more.