### PR TITLE
Make closure parsing work on all `%S` output

### DIFF
--- a/test/tests/regression.es
+++ b/test/tests/regression.es
@@ -97,7 +97,7 @@ EOF
 	assert {$es -c 'catch @ {} {%pathsearch %pnothingthatreallyexists}'} '%-like strings don''t break %pathsearch'
 
 	# https://github.com/wryun/es-shell/issues/246
-	let (x = \e^';')
+	let (x = \e^';'^\e^';'^\e^';')
 	local (fn ok {true})
 	assert {$es -c ok}
 }


### PR DESCRIPTION
This is related to #242 and #246.

Sometimes when we want to format strings with `%S`, we get a concat, like in `\e^';'`).  This historically couldn't be handled by the closure-parsing logic.  This PR makes that logic able to handle this case.

It's not a general fix for closure parsing, but it's enough to fix (I think) anything that `Sconv()` can actually produce.  Making unnatural, "manual" `%closure` strings not crash the shell is still on the todo list.