### PR TITLE
Parse more %closures and throw exceptions for others

### DIFF
--- a/closure.c
+++ b/closure.c
@@ -76,12 +76,16 @@ static Binding *extract(Tree *tree, Binding *bindings) {
 			for (; defn != NULL; defn = defn->u[1].p) {
 				Term *term;
 				Tree *word = defn->u[0].p;
-				NodeKind k = word->kind;
 				assert(defn->kind == nList);
-				assert(k == nWord || k == nQword || k == nPrim || k == nConcat);
-				if (k == nPrim) {
-					char *prim = word->u[0].s;
-					if (streq(prim, "nestedbinding")) {
+				switch (word->kind) {
+				case nConcat:
+					term = mkstr(doconcat(word));
+					break;
+				case nWord: case nQword:
+					term = mkstr(word->u[0].s);
+					break;
+				case nPrim: {
+					if (streq(word->u[0].s, "nestedbinding")) {
 						int i, count;
 						Chain *cp;
 						if (
@@ -101,14 +105,19 @@ static Binding *extract(Tree *tree, Binding *bindings) {
 								break;
 						}
 						term = mkterm(NULL, cp->closure);
-					} else {
-						fail("$&parse", "bad unquoted primitive in %%closure: $&%s", prim);
-						NOTREACHED;
+						break;
 					}
-				} else if (k == nConcat)
-					term = mkstr(doconcat(word));
-				else
-					term = mkstr(word->u[0].s);
+				}
+				FALLTHROUGH;
+				case nLambda: case nThunk:
+					term = mkterm(NULL, mkclosure(word, NULL));
+					break;
+				case nCall: case nVar: case nVarsub:
+					fail("$&parse", "bad definition in %%closure: %T\n", defn);
+					NOTREACHED;
+				default:
+					NOTREACHED;
+				}
 				list = mklist(term, list);
 			}
 			bindings = mkbinding(name->u[0].s, list, bindings);


### PR DESCRIPTION
Fixes #242.

This adds more explicit handling for the different kinds of things that could be in a `'%closure'` string, such as thunks or lambdas or primitives, even if they generally shouldn't show up there with normal use.

We can't really parse things such as calls or variables, since they would require glomming.  However, since the only cases of `%closure` we really care about are ones generated _after_ glomming, where we shouldn't see calls or variables here, we can just throw an exception and not worry too much about it.

The way it is written still leaves it possible in theory for closure parsing to crash on an assertion failure, but I can't actually summon up any of the other tree kinds that would cause that to happen.

I considered including the `$&nestedbinding` stuff in here to really make the shell "closure-proof", but in testing it with the classic `letrec` example `odd?` and `even?` functions, it didn't actually work right.  I haven't looked into how it actually works.  Maybe in a future PR (and even then, only as a temporary solution, since it doesn't handle the shared-closure problem.)