### PR TITLE
Split $&read return value on NUL characters.

### DIFF
--- a/doc/es.1
+++ b/doc/es.1
@@ -2273,10 +2273,10 @@ and repeats.
 .Cr "%read"
 Reads from standard input and returns either the empty list (in the
 case of end-of-file) or a single element string with up to one line of
-data, including possible redirections.  This function reads one
-character at a time in order to not read more data out of a pipe than
-it should.  The terminating newline (if present) is not included in
-the returned string.
+data, including possible redirections.
+Any NUL characters encountered while reading are skipped.
+The terminating newline (if present) is not included in the returned
+string.
 .SS "Hook Functions"
 A subset of the
 .Cr % -named
@@ -2713,6 +2713,11 @@ and
 primitives are used by the implementation of the
 .Cr vars
 builtin.
+The
+.Cr read
+primitive is used by the implementation of the
+.Cr %read
+builtin, but splits its read-in line on NUL characters.
 .PP
 The following primitives implement the hook functions
 of the same names, with
@@ -2721,11 +2726,11 @@ prefixes:
 .ta 1.75i 3.5i
 .Ds
 .ft \*(Cf
-apids	here	read
-close	home	run
-count	newfd	seq
-dup	openfile	split
-flatten	var	fsplit
+apids	here	run
+close	home	seq
+count	newfd	split
+dup	openfile	fsplit
+flatten	var
 pipe	whatis
 .ft R
 .De

--- a/initial.es
+++ b/initial.es
@@ -78,8 +78,6 @@ fn-throw	= $&throw
 fn-umask	= $&umask
 fn-wait		= $&wait
 
-fn-%read	= $&read
-
 #	eval runs its arguments by turning them into a code fragment
 #	(in string form) and running that fragment.
 
@@ -101,6 +99,13 @@ fn-false	= { result 1 }
 fn-break	= throw break
 fn-exit		= throw exit
 fn-return	= throw return
+
+#	The %read builtin wraps the $&read primitive, which splits its
+#	return value on NUL characters.  This is done so that other ways
+#	to handle NULs can be implemented, while keeping the behavior
+#	of %read predictable.
+
+fn-%read	= { %flatten '' <=$&read }
 
 #	unwind-protect is a simple wrapper around catch that is used
 #	to ensure that some cleanup code is run after running a code

--- a/prim-io.c
+++ b/prim-io.c
@@ -441,52 +441,54 @@ static int readn(int fd, char *s, size_t n) {
 PRIM(read) {
 	int c;
 	int fd = fdmap(0);
-
-	static Buffer *buffer = NULL;
-	if (buffer != NULL)
-		freebuffer(buffer);
-	buffer = openbuffer(0);
+	Buffer *buffer = openbuffer(0);
+	Ref(List *, result, NULL);
 
 #if HAVE_LSEEK
-	if (lseek(fd, 0, SEEK_CUR) < 0) {
-#endif
-		while ((c = read1(fd)) != EOF && c != '\n')
-			if (c == '\0')
-				fail("$&read", "%%read: null character encountered");
-			else
-				buffer = bufputc(buffer, c);
-#if HAVE_LSEEK
-	} else {
+	if (lseek(fd, 0, SEEK_CUR) >= 0) {
 		int n;
 		char *np, *zp;
-		char s[BUFSIZE];
+		char buf[BUFSIZE];
 		c = EOF;
-		while ((n = readn(fd, s, BUFSIZE)) > 0) {
+		while ((n = readn(fd, buf, BUFSIZE)) > 0) {
+			char *s = buf;
 			c = 0;
-			if ((np = strchr(s, '\n')) != NULL) {
+			if ((np = memchr(s, '\n', n)) != NULL) {
 				lseek(fd, 1 + ((np - s) - n), SEEK_CUR);
 				n = np - s;
 			}
-			if ((zp = memchr(s, '\0', n)) != NULL) {
-				lseek(fd, 1 + ((zp - s) - n), SEEK_CUR);
-				fail("$&read", "%%read: null character encountered");
+			while ((zp = memchr(s, '\0', n)) != NULL) {
+				Term *term;
+				buffer = bufncat(buffer, s, zp - s);
+				n -= zp - s + 1;
+				s = zp + 1;
+				term = mkstr(sealcountedbuffer(buffer));
+				result = mklist(term, result);
+				buffer = openbuffer(0);
 			}
 			buffer = bufncat(buffer, s, n);
-			if (np != NULL && *np == '\n')
+			if (np != NULL)
 				break;
 		}
-	}
+	} else
 #endif
+		while ((c = read1(fd)) != EOF && c != '\n')
+			if (c == '\0') {
+				Term *term = mkstr(sealcountedbuffer(buffer));
+				result = mklist(term, result);
+				buffer = openbuffer(0);
+			} else
+				buffer = bufputc(buffer, c);
 
 	if (c == EOF && buffer->current == 0) {
 		freebuffer(buffer);
-		buffer = NULL;
-		return NULL;
 	} else {
-		List *result = mklist(mkstr(sealcountedbuffer(buffer)), NULL);
-		buffer = NULL;
-		return result;
+		Term *term = mkstr(sealcountedbuffer(buffer));
+		result = mklist(term, result);
 	}
+
+	result = reverse(result);
+	RefReturn(result);
 }
 
 extern Dict *initprims_io(Dict *primdict) {

--- a/test/tests/read.es
+++ b/test/tests/read.es
@@ -6,31 +6,21 @@ test 'null reading' {
 		echo first line	 > $tmp
 		./testrun 0	>> $tmp
 
-		let (fl = (); ex = (); remainder = ()) {
-			catch @ e {
-				ex = $e
-				remainder = <=%read
-			} {
-				fl = <=%read
-				%read
+		let (first = (); second = ()) {
+			{
+				first = <=%read
+				second = <=%read
 			} < $tmp
-			assert {~ $fl 'first line'} 'seeking read reads valid line'
-			assert {~ $ex(3) *'null character encountered'*} 'seeking read throws exception correctly'
-			assert {~ $remainder 'sult 6'} 'seeking read leaves file in correct state:' $remainder
+			assert {~ $first 'first line'} 'read reads valid line'
+			assert {~ $second 'result 6'} 'read reads line with zero'
 		}
 
-		let ((fl ex remainder) = `` \n {
+		let ((first second) = `` \n {
 			let (fl = ())
-			cat $tmp | catch @ e {
-				echo $fl\n$e(3)\n^<=%read
-			} {
-				fl = <=%read
-				%read
-			}
+			cat $tmp | {echo <=%read^\n^<=%read}
 		}) {
-			assert {~ $fl 'first line'} 'non-seeking read reads valid line'
-			assert {~ $ex *'null character encountered'*} 'non-seeking read throws exception correctly'
-			assert {~ $remainder 'sult 6'} 'non-seeking read leaves file in correct state'
+			assert {~ $first 'first line'} 'pipe read reads valid line'
+			assert {~ $second 'result 6'} 'pipe read reads line with zero'
 		}
 	} {
 		rm -f $tmp

--- a/test/tests/regression.es
+++ b/test/tests/regression.es
@@ -62,7 +62,7 @@ test 'regressions' {
 	}}
 
 	# https://github.com/wryun/es-shell/issues/93
-	assert {./testrun 0 | {catch @ {} {%read}}}
+	assert {./testrun 0 | {catch @ {} {%read >[2] /dev/null; true}}}
 
 	# https://github.com/wryun/es-shell/issues/99
 	assert {$es -c {catch @ {} {echo >[1=]}}}


### PR DESCRIPTION
This should allow flexible handling of `NUL`s without having to add any unnecessary flags to `$&read`.  By wrapping the primitive appropriately people should be able to "use" NUL bytes like to work with GNU `find -print0`; they can skip them, like some other shells (bash, dash) do and like `%parse` wants, they can skip them but print a warning, or they can throw an exception when encountering them.

`%read` has been changed in initial.es so that it `$&read` to skip over `NUL`s.  The idea here is that `NUL` bytes are generally rare, so having `%read` only _rarely_ return multiple elements is probably a recipe for unpleasant surprises.

This is backwards-compatibility-breaking, but there is little backwards compatibility here to consider -- until #146, `$&read`ing a NUL byte caused the shell to crash, and using an exception was only a stop-gap because just about anything is better than crashing.  Now I think I've convinced myself that this is the best behavior for actually being able to handle NUL bytes.

Some thoughts about future, follow-on changes to `$&read`:
 - I think it may make sense at some point to add a "read _n_ bytes" mode
 - I think it may make sense at some point to add a "read until delimiter _d_" mode, potentially being able to configure zero or more delimiters (where zero delimiters means "read everything", and we figure out a way to communicate which delimiter was reached)
 - For now at least, line-by-line processing seems to work well enough; the above are more-or-less just performance optimizations
 - I think `$&read` should only ever split its input on NULs: performing other splitting makes the NUL-splitting ambiguous, and wrappers and callers can just use `%split` or `%fsplit`.
 - I think it makes sense to add seeking, but I'm not sure how that would look.