### PR TITLE
Reduce unnecessary work in new parse() and fill()

### DIFF
--- a/es.h
+++ b/es.h
@@ -108,7 +108,7 @@ extern void closefds(void);
 extern int fdmap(int fd);
 extern int defer_mvfd(Boolean parent, int old, int new);
 extern int defer_close(Boolean parent, int fd);
-extern void undefer(int ticket);
+extern void undefer(int ticket, Boolean doclose);
 
 
 /* term.c */

--- a/fd.c
+++ b/fd.c
@@ -76,7 +76,7 @@ extern int defer_close(Boolean parent, int fd) {
 	return pushdefer(parent, -1, fd);
 }
 
-extern void undefer(int ticket) {
+extern void undefer(int ticket, Boolean doclose) {
 	if (ticket != UNREGISTERED) {
 		Defer *defer;
 		assert(ticket >= 0);
@@ -84,7 +84,7 @@ extern void undefer(int ticket) {
 		defer = &deftab[--defcount];
 		assert(ticket == defcount);
 		unregisterfd(&defer->realfd);
-		if (defer->realfd != -1)
+		if (doclose && defer->realfd != -1)
 			close(defer->realfd);
 	}
 }

--- a/input.c
+++ b/input.c
@@ -53,6 +53,8 @@ static int fill(Parser *p) {
 	if (p->reader != NULL) {
 		result = eval(p->reader, NULL, 0);
 		read = str("%L\n", result, " ");
+	} else if (in->fd == -1) {
+		result = NULL;
 	} else {
 		result = prim("read", NULL, 0);
 		RefAdd(result);
@@ -112,7 +114,7 @@ static void initbuf(Parser *p) {
  */
 extern Tree *parse(List *reader) {
 	volatile int result;
-	int fd, ticket = UNREGISTERED;
+	int ticket = UNREGISTERED;
 	Parser p;
 	void *oldpspace;
 	List *volatile readexception = NULL;
@@ -133,10 +135,17 @@ extern Tree *parse(List *reader) {
 	initbuf(&p);
 	p.tokenbuf = ealloc(p.bufsize);
 
-	fd = (input->fd == -1)
-		? eopen("/dev/null", oOpen)
-		: dup(input->fd);
-	ticket = defer_mvfd(TRUE, fd, 0);
+	if (input->fd > -1 || reader != NULL) {
+		int fd;
+		static int devnull = -1;
+		if (input->fd == -1) {
+			if (devnull == -1)
+				devnull = eopen("/dev/null", oOpen);
+			fd = devnull;
+		} else
+			fd = input->fd;
+		ticket = defer_mvfd(TRUE, fd, 0);
+	}
 
 	ExceptionHandler
 
@@ -148,13 +157,11 @@ extern Tree *parse(List *reader) {
 
 	EndExceptionHandler
 
-	undefer(ticket);
+	undefer(ticket, FALSE);
 	RefRemove(p.reader);
 	assert(p.ungot == 0);
-	if (p.bufbegin != NULL)
-		efree(p.bufbegin);
-	if (p.tokenbuf != NULL)
-		efree(p.tokenbuf);
+	efree(p.bufbegin);
+	efree(p.tokenbuf);
 
 	if (result || p.error != NULL || readexception != NULL) {
 		assert(p.error != NULL || readexception != NULL);

--- a/prim-io.c
+++ b/prim-io.c
@@ -32,9 +32,9 @@ static List *redir(List *(*rop)(int *fd, List *list), List *list, int evalflags)
 		   : defer_mvfd(inparent, srcfd, destfd);
 	ExceptionHandler
 		lp = eval(lp, NULL, evalflags);
-		undefer(ticket);
+		undefer(ticket, TRUE);
 	CatchException (e)
-		undefer(ticket);
+		undefer(ticket, TRUE);
 		throw(e);
 	EndExceptionHandler
 
@@ -197,14 +197,14 @@ PRIM(here) {
 	ExceptionHandler
 		lp = eval(cmd, NULL, evalflags);
 	CatchException (e)
-		undefer(ticket);
+		undefer(ticket, TRUE);
 		close(p[0]);
 		if (pid > 0)
 			ewaitfor(pid);
 		throw(e);
 	EndExceptionHandler
 
-	undefer(ticket);
+	undefer(ticket, TRUE);
 	close(p[0]);
 	if (pid > 0) {
 		status = ewaitfor(pid);


### PR DESCRIPTION
Parsing raw strings doesn't involve a reader command or input file (think `eval`, or parsing functions from the environment).  In these cases we can skip unnecessary file management and `$&read` calls with no cost to users.

Also skip unnecessarily `dup()`ing the input fd when redirecting to it.

Part of #267, though admittedly the practical impact of this is relatively small.