### PR TITLE
Some fixes for parsing, reading, and syntax

### DIFF
--- a/heredoc.c
+++ b/heredoc.c
@@ -11,7 +11,7 @@ struct Here {
 };
 
 /* getherevar -- read a variable from a here doc */
-extern Tree *getherevar(Parser *p) {
+static Tree *getherevar(Parser *p) {
 	int c;
 	char *s;
 	size_t len;
@@ -30,7 +30,7 @@ extern Tree *getherevar(Parser *p) {
 }
 
 /* snarfheredoc -- read a heredoc until the eof marker */
-extern Tree *snarfheredoc(Parser *p, const char *eof, Boolean quoted) {
+static Tree *snarfheredoc(Parser *p, const char *eof, Boolean quoted) {
 	Tree *tree, **tailp;
 	Buffer *buf;
 	unsigned char *s;
@@ -43,7 +43,6 @@ extern Tree *snarfheredoc(Parser *p, const char *eof, Boolean quoted) {
 
 	for (tree = NULL, tailp = &tree, buf = openbuffer(0);;) {
 		int c;
-		p->input->lineno++;
 		for (s = (unsigned char *) eof; (c = get(p)) == *s; s++)
 			;
 		if (*s == '\0' && (c == '\n' || c == EOF)) {

--- a/input.c
+++ b/input.c
@@ -48,7 +48,7 @@ static int fill(Parser *p) {
 	size_t nread;
 	Input *in = p->input;
 
-	assert(p->buf == p->bufend);
+	assert(in->buf == in->bufend);
 
 	if (p->reader != NULL) {
 		result = eval(p->reader, NULL, 0);
@@ -67,28 +67,31 @@ static int fill(Parser *p) {
 		in->eof = TRUE;
 		return EOF;
 	}
-	if ((nread = strlen(read)) > p->buflen) {
-		p->bufbegin = erealloc(p->bufbegin, nread);
-		p->buflen = nread;
+	if ((nread = strlen(read)) > in->buflen) {
+		in->bufbegin = erealloc(in->bufbegin, nread);
+		in->buflen = nread;
 	}
-	memcpy(p->bufbegin, read, nread);
+	memcpy(in->bufbegin, read, nread);
 
-	p->buf = p->bufbegin;
-	p->bufend = &p->buf[nread];
+	in->buf = in->bufbegin;
+	in->bufend = &in->buf[nread];
 
-	return *p->buf++;
+	return *in->buf++;
 }
 
 /* get -- get a character, filter out nulls */
 extern int get(Parser *p) {
 	int c;
+	Input *in = p->input;
 	if (p->ungot > 0)
 		return p->unget[--p->ungot];
-	c = p->buf < p->bufend ? *p->buf++ : fill(p);
+	c = in->buf < in->bufend ? *in->buf++ : fill(p);
 	if (c != EOF && p->input->runflags & run_echoinput) {
 		char buf = (char)c;
 		ewrite(2, &buf, 1);
 	}
+	if (c == '\n')
+		p->input->lineno++;
 	return c;
 }
 
@@ -98,15 +101,15 @@ extern void unget(Parser *p, int c) {
 	p->unget[p->ungot++] = c;
 }
 
-static void initbuf(Parser *p) {
-	const char *initial = p->input->str;
-	p->buflen = initial == NULL ? BUFSIZE : strlen(initial);
-	p->bufbegin = p->buf = ealloc(p->buflen);
+static void initbuf(Input *in) {
+	const char *initial = in->str;
+	in->buflen = initial == NULL ? BUFSIZE : strlen(initial);
+	in->bufbegin = in->buf = ealloc(in->buflen);
 	if (initial != NULL) {
-		memcpy(p->buf, initial, p->buflen);
-		p->bufend = p->bufbegin + p->buflen;
+		memcpy(in->buf, initial, in->buflen);
+		in->bufend = in->bufbegin + in->buflen;
 	} else
-		p->bufend = p->bufbegin;
+		in->bufend = in->bufbegin;
 }
 
 /*
@@ -132,7 +135,6 @@ extern Tree *parse(List *reader) {
 	oldpspace = setpspace(p.space);
 
 	inityy(&p);
-	initbuf(&p);
 	p.tokenbuf = ealloc(p.bufsize);
 
 	if (input->fd > -1 || reader != NULL) {
@@ -159,8 +161,6 @@ extern Tree *parse(List *reader) {
 
 	undefer(ticket, FALSE);
 	RefRemove(p.reader);
-	assert(p.ungot == 0);
-	efree(p.bufbegin);
 	efree(p.tokenbuf);
 
 	if (result || p.error != NULL || readexception != NULL) {
@@ -175,6 +175,7 @@ extern Tree *parse(List *reader) {
 		RefEnd(e);
 	}
 
+	assert(p.ungot == 0);
 	Ref(Tree *, tree, pseal(p.tree));
 	setpspace(oldpspace);
 #if LISPTREES
@@ -191,6 +192,7 @@ extern Tree *parse(List *reader) {
 
 /* cleanup -- clean up after an input source */
 static void cleanup(Input *in) {
+	efree(in->bufbegin);
 	if (in->fd != -1) {
 		unregisterfd(&in->fd);
 		close(in->fd);
@@ -211,6 +213,7 @@ extern List *runinput(Input *in, int runflags) {
 		"fn-%noeval-print",
 	};
 
+	initbuf(in);
 	flags &= ~eval_inchild;
 	in->runflags = flags;
 	input = in;
@@ -299,6 +302,7 @@ extern Tree *parseinput(Input *in) {
 	Tree * volatile result = NULL;
 	Input *prev = input;
 
+	initbuf(in);
 	in->runflags = 0;
 	input = in;
 

--- a/input.h
+++ b/input.h
@@ -11,6 +11,10 @@ struct Input {
 	int fd;
 	Boolean eof;
 	int runflags;
+
+	/* read buffer */
+	size_t buflen;
+	unsigned char *buf, *bufend, *bufbegin;
 };
 
 typedef enum { NW, RW, KW } WordState;	/* nonword, realword, keyword */
@@ -25,10 +29,6 @@ struct Parser {
 	Tree *tree;		/* the final parse tree */
 	Here *hereq;		/* pending here document queue */
 	const char *error;	/* syntax error, if it exists */
-
-	/* read buffer */
-	size_t buflen;
-	unsigned char *buf, *bufend, *bufbegin;
 
 	/* token pushback buffer */
 	int ungot, unget[MAXUNGET];

--- a/match.c
+++ b/match.c
@@ -196,7 +196,6 @@ static List *extractsinglematch(const char *subject, const char *pattern,
 					return mklist(mkstr(gcdup(s)), result);
 				for (begin = s;; s++) {
 					const char *q = TAILQUOTE(quoting, i);
-					assert(*s != '\0');
 					if (match(s, pattern + i, q)) {
 						result = mklist(mkstr(gcndup(begin, s - begin)), result);
 						return haswild(pattern + i, q)

--- a/syntax.c
+++ b/syntax.c
@@ -138,8 +138,13 @@ extern Tree *redirect(Parser *p, Tree *t) {
 		return t;
 	r = t->CAR;
 	t = t->CDR;
-	for (; r->kind == nRedir; r = r->CDR)
+	for (; r->kind == nRedir; r = r->CDR) {
+		if (t->kind != nList && t->kind != nRedir) {
+			yyerror(p, "bad command in /dev/fd redirection");
+			return NULL;
+		}
 		t = treeappend(t, r->CAR);
+	}
 	for (rp = r; rp->CAR != &placeholder; rp = rp->CDR) {
 		assert(rp != NULL);
 		assert(rp->kind == nList);

--- a/test/tests/regression.es
+++ b/test/tests/regression.es
@@ -108,6 +108,10 @@ EOF
 	# https://github.com/wryun/es-shell/pull/255
 	local (fn %pathsearch {result ~})
 	assert {$es -c 'notarealbinary; true'}
+
+	assert {~ `` \n {$es -nc '<< !EOF &' >[2=1]} *'literal word'*}
+	assert {~ `` \n {$es -nc '>{} a=b' >[2=1]} *'redirection'*}
+	assert {$es -c '~~ 0x 0?**; true'}
 }
 
 # These tests are based on notes in the CHANGES file from the pre-git days.

--- a/token.c
+++ b/token.c
@@ -201,8 +201,6 @@ top:	while ((c = get(p)) == ' ' || c == '\t')
 		i = 0;
 		while ((c = get(p)) != '\'' || (c = get(p)) == '\'') {
 			buf[i++] = c;
-			if (c == '\n')
-				p->input->lineno++;
 			if (c == EOF) {
 				p->ws = NW;
 				scanerror(p, c, "eof in quoted string");
@@ -217,7 +215,6 @@ top:	while ((c = get(p)) == ' ' || c == '\t')
 		return QWORD;
 	case '\\':
 		if ((c = get(p)) == '\n') {
-			p->input->lineno++;
 			unget(p, ' ');
 			goto top; /* Pretend it was just another space. */
 		}
@@ -283,7 +280,6 @@ top:	while ((c = get(p)) == ' ' || c == '\t')
 				return ENDFILE;
 		FALLTHROUGH;
 	case '\n':
-		p->input->lineno++;
 		p->ws = NW;
 		return NL;
 	case '(':


### PR DESCRIPTION
- Change how line counting is done, fixing an off-by-one problem in heredocs
- Buffer reads in `Input`s rather than `Parser`s, fixing lost input if multiple commands worth of input are returned at once
- Remove/move a couple of `assert()`s which the fuzzer managed to trip
- Add a manual check for funky redirection syntax which the fuzzer managed to trip