### PR TITLE
Include git commit in $&version return value

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -107,7 +107,7 @@ token.h	: parse.y
 
 y.tab.c	: token.h
 
-version.h : mkversion
+version.h : mkversion .git/index
 	(cd $(srcdir) && sh mkversion) > version.h
 
 initial.c : esdump $(srcdir)/initial.es

--- a/mkversion
+++ b/mkversion
@@ -1,10 +1,14 @@
 #!/bin/sh
 
 VERSION=0.10.0
-RELEASEDATE=15-Feb-2026
-GITINFO=""
-if ! [ "$(git describe --tags)" = "v$VERSION" ]; then
-	GITINFO=" $(git rev-parse --short HEAD)"
-fi
+DATE=15-Feb-2026
 
-echo "#define VERSION \"es version $VERSION $RELEASEDATE$GITINFO\""
+COMMIT=""
+case "$(git describe --tags 2>/dev/null)" in
+"v$VERSION-"*)
+	COMMIT=" $(git rev-parse --short HEAD)"
+	DATE="$(git show --no-patch --format=%cd --date=format:'%d-%b-%Y')"
+	;;
+esac
+
+echo "#define VERSION \"es version $VERSION $DATE$COMMIT\""

--- a/mkversion
+++ b/mkversion
@@ -2,5 +2,9 @@
 
 VERSION=0.10.0
 RELEASEDATE=15-Feb-2026
+GITINFO=""
+if ! [ "$(git describe --tags)" = "v$VERSION" ]; then
+	GITINFO=" $(git rev-parse --short HEAD)"
+fi
 
-echo "#define VERSION \"es version $VERSION $RELEASEDATE\""
+echo "#define VERSION \"es version $VERSION $RELEASEDATE$GITINFO\""


### PR DESCRIPTION
This PR makes it so that, if:
 - building from a git repo, and
 - if HEAD is not currently tagged with `v$VERSION` with the `VERSION` set in the `mkversion` script,

then the return value of `$&version` looks like
```
; es -c 'echo <=$&version'
es version 0.10.0 17-May-2026 24375d3
```
where the date given is the date of the commit, and the commit's short hash is included after the other elements.

Unlike #172, this format should be totally backwards compatible for released versions, either when built from the git repo OR from a tarball.  However, lots of folks download and build _es_ from HEAD; for those people, this output is more informative.

Fixes #147.